### PR TITLE
Document locked line technique

### DIFF
--- a/src/logic/techniques.ts
+++ b/src/logic/techniques.ts
@@ -2,6 +2,7 @@ import type { PuzzleState } from '../types/puzzle';
 import type { Hint, TechniqueId } from '../types/hints';
 import { addLogEntry, store } from '../store/puzzleStore';
 import { findTrivialMarksHint } from './techniques/trivialMarks';
+import { findLockedLineHint } from './techniques/lockedLine';
 import { findTwoByTwoHint } from './techniques/twoByTwo';
 import { findCrossPressureHint } from './techniques/crossPressure';
 import { findSharedRowColumnHint } from './techniques/sharedRowColumn';
@@ -37,6 +38,11 @@ export const techniquesInOrder: Technique[] = [
     id: 'trivial-marks',
     name: 'Trivial Marks',
     findHint: findTrivialMarksHint,
+  },
+  {
+    id: 'locked-line',
+    name: 'Locked Row/Column',
+    findHint: findLockedLineHint,
   },
   {
     id: 'two-by-two',

--- a/src/logic/techniques/lockedLine.ts
+++ b/src/logic/techniques/lockedLine.ts
@@ -1,0 +1,141 @@
+import type { PuzzleState, Coords } from '../../types/puzzle';
+import type { Hint } from '../../types/hints';
+import {
+  colCells,
+  formatCol,
+  formatRegion,
+  formatRow,
+  neighbors8,
+  regionCells,
+  rowCells,
+} from '../helpers';
+
+let hintCounter = 0;
+
+function nextHintId() {
+  hintCounter += 1;
+  return `locked-line-${hintCounter}`;
+}
+
+/**
+ * Locked Line:
+ *
+ * When all viable cells for the remaining stars in a region fall in a single row
+ * or column, any other cells in that line outside the region cannot contain a
+ * star and must be crossed out.
+ */
+function computeCounts(state: PuzzleState) {
+  const { size } = state.def;
+  const rowStars = new Array(size).fill(0);
+  const colStars = new Array(size).fill(0);
+  const regionStars = new Map<number, number>();
+
+  for (let r = 0; r < size; r += 1) {
+    for (let c = 0; c < size; c += 1) {
+      if (state.cells[r][c] === 'star') {
+        rowStars[r] += 1;
+        colStars[c] += 1;
+        const regionId = state.def.regions[r][c];
+        regionStars.set(regionId, (regionStars.get(regionId) ?? 0) + 1);
+      }
+    }
+  }
+
+  return { rowStars, colStars, regionStars };
+}
+
+function cellKey(cell: Coords): string {
+  return `${cell.row},${cell.col}`;
+}
+
+function getViableCellsForRegion(
+  state: PuzzleState,
+  regionId: number,
+  rowStars: number[],
+  colStars: number[],
+): Coords[] {
+  const { starsPerUnit } = state.def;
+  const cells = regionCells(state, regionId);
+  const viable: Coords[] = [];
+
+  for (const cell of cells) {
+    const cellState = state.cells[cell.row][cell.col];
+
+    if (cellState === 'cross') continue;
+    if (cellState === 'star') {
+      viable.push(cell);
+      continue;
+    }
+
+    if (rowStars[cell.row] >= starsPerUnit) continue;
+    if (colStars[cell.col] >= starsPerUnit) continue;
+
+    const hasAdjacentStar = neighbors8(cell, state.def.size).some(nb => state.cells[nb.row][nb.col] === 'star');
+    if (!hasAdjacentStar) {
+      viable.push(cell);
+    }
+  }
+
+  return viable;
+}
+
+export function findLockedLineHint(state: PuzzleState): Hint | null {
+  const { size, starsPerUnit } = state.def;
+  const { rowStars, colStars, regionStars } = computeCounts(state);
+
+  for (let regionId = 1; regionId <= size; regionId += 1) {
+    const existingStars = regionStars.get(regionId) ?? 0;
+    const needsStars = starsPerUnit - existingStars;
+    if (needsStars <= 0) continue;
+
+    const viableCells = getViableCellsForRegion(state, regionId, rowStars, colStars);
+    if (viableCells.length < needsStars || viableCells.length === 0) continue;
+
+    const rowSet = new Set(viableCells.map(c => c.row));
+    const colSet = new Set(viableCells.map(c => c.col));
+
+    if (rowSet.size === 1) {
+      const [targetRow] = Array.from(rowSet);
+      const regionCellKeys = new Set(viableCells.map(cellKey));
+      const crosses = rowCells(state, targetRow).filter(cell => {
+        if (regionCellKeys.has(cellKey(cell))) return false;
+        if (state.cells[cell.row][cell.col] !== 'empty') return false;
+        return state.def.regions[cell.row][cell.col] !== regionId;
+      });
+
+      if (crosses.length === 0) continue;
+
+      return {
+        id: nextHintId(),
+        kind: 'place-cross',
+        technique: 'locked-line',
+        resultCells: crosses,
+        explanation: `All possible cells for region ${formatRegion(regionId)} are in ${formatRow(targetRow)}, so every other cell in that row must be a cross.`,
+        highlights: { rows: [targetRow], regions: [regionId], cells: crosses },
+      };
+    }
+
+    if (colSet.size === 1) {
+      const [targetCol] = Array.from(colSet);
+      const regionCellKeys = new Set(viableCells.map(cellKey));
+      const crosses = colCells(state, targetCol).filter(cell => {
+        if (regionCellKeys.has(cellKey(cell))) return false;
+        if (state.cells[cell.row][cell.col] !== 'empty') return false;
+        return state.def.regions[cell.row][cell.col] !== regionId;
+      });
+
+      if (crosses.length === 0) continue;
+
+      return {
+        id: nextHintId(),
+        kind: 'place-cross',
+        technique: 'locked-line',
+        resultCells: crosses,
+        explanation: `All possible cells for region ${formatRegion(regionId)} are in ${formatCol(targetCol)}, so every other cell in that column must be a cross.`,
+        highlights: { cols: [targetCol], regions: [regionId], cells: crosses },
+      };
+    }
+  }
+
+  return null;
+}

--- a/src/types/hints.ts
+++ b/src/types/hints.ts
@@ -3,6 +3,7 @@ import type { Coords } from './puzzle';
 export type TechniqueId =
   // 1. The basics
   | 'trivial-marks'
+  | 'locked-line'
   | 'two-by-two'
   | 'cross-pressure'
   | 'shared-row-column'

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -838,6 +838,7 @@ describe('Integration Tests: Guide Example Sequences', () => {
     const firstTechnique = techniquesUsed[0];
     const basicTechniques: TechniqueId[] = [
       'trivial-marks',
+      'locked-line',
       'two-by-two',
       'one-by-n',
       'exclusion',
@@ -907,9 +908,10 @@ describe('Integration Tests: Guide Example Sequences', () => {
 });
 
 describe('Integration Tests: Technique Verification', () => {
-  it('verifies all 24 techniques are registered', () => {
+  it('verifies all 25 techniques are registered', () => {
     const expectedTechniques: TechniqueId[] = [
       'trivial-marks',
+      'locked-line',
       'two-by-two',
       'cross-pressure',
       'shared-row-column',
@@ -934,8 +936,8 @@ describe('Integration Tests: Technique Verification', () => {
       'by-a-thread-at-sea',
       'entanglement',
     ];
-    
-    expect(techniquesInOrder.length).toBe(24);
+
+    expect(techniquesInOrder.length).toBe(25);
     
     const registeredIds = techniquesInOrder.map(t => t.id);
     
@@ -947,6 +949,7 @@ describe('Integration Tests: Technique Verification', () => {
   it('verifies techniques are in correct order', () => {
     const expectedOrder: TechniqueId[] = [
       'trivial-marks',
+      'locked-line',
       'two-by-two',
       'cross-pressure',
       'shared-row-column',

--- a/tests/lockedLine.test.ts
+++ b/tests/lockedLine.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { createEmptyPuzzleDef, createEmptyPuzzleState } from '../src/types/puzzle';
+import { TEST_REGIONS } from './testBoard';
+import { findLockedLineHint } from '../src/logic/techniques/lockedLine';
+import { findNextHint } from '../src/logic/techniques';
+
+function cellKey(row: number, col: number) {
+  return `${row},${col}`;
+}
+
+describe('Locked Row/Column technique', () => {
+  it('marks all other cells in a row when a region is confined to that row', () => {
+    const def = createEmptyPuzzleDef();
+    def.regions = TEST_REGIONS;
+    const state = createEmptyPuzzleState(def);
+
+    // Constrain region 6 to row 8 by crossing out its row 9 cells
+    state.cells[9][0] = 'cross';
+    state.cells[9][1] = 'cross';
+    state.cells[9][2] = 'cross';
+
+    const hint = findLockedLineHint(state);
+    expect(hint).not.toBeNull();
+    expect(hint?.technique).toBe('locked-line');
+
+    const expectedCrosses = new Set([
+      cellKey(8, 0),
+      cellKey(8, 1),
+      cellKey(8, 5),
+      cellKey(8, 6),
+      cellKey(8, 7),
+      cellKey(8, 8),
+      cellKey(8, 9),
+    ]);
+
+    const actualCrosses = new Set(hint?.resultCells.map(c => cellKey(c.row, c.col)) ?? []);
+    expect(actualCrosses).toEqual(expectedCrosses);
+  });
+
+  it('appears early in the technique chain', () => {
+    const def = createEmptyPuzzleDef();
+    def.regions = TEST_REGIONS;
+    const state = createEmptyPuzzleState(def);
+
+    state.cells[9][0] = 'cross';
+    state.cells[9][1] = 'cross';
+    state.cells[9][2] = 'cross';
+
+    const hint = findNextHint(state);
+    expect(hint?.technique).toBe('locked-line');
+  });
+});

--- a/tests/techniqueOrdering.test.ts
+++ b/tests/techniqueOrdering.test.ts
@@ -10,6 +10,7 @@ describe('Technique Ordering', () => {
     // before general uniqueness techniques (by-a-thread) to ensure they get tried first
     const expectedOrder: TechniqueId[] = [
       'trivial-marks',
+      'locked-line',
       'two-by-two',
       'cross-pressure',
       'shared-row-column',
@@ -42,6 +43,7 @@ describe('Technique Ordering', () => {
   it('should have all technique IDs mapped to names', () => {
     const allTechniqueIds: TechniqueId[] = [
       'trivial-marks',
+      'locked-line',
       'two-by-two',
       'cross-pressure',
       'shared-row-column',
@@ -74,8 +76,8 @@ describe('Technique Ordering', () => {
     }
   });
 
-  it('should have exactly 24 techniques registered', () => {
-    expect(techniquesInOrder).toHaveLength(24);
+  it('should have exactly 25 techniques registered', () => {
+    expect(techniquesInOrder).toHaveLength(25);
   });
 
   it('should have unique technique IDs', () => {


### PR DESCRIPTION
## Summary
- add a descriptive header comment to the locked-line technique for clarity and consistency

## Testing
- CI=1 pnpm vitest run lockedLine.test.ts techniqueOrdering.test.ts integration.test.ts --reporter basic

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fce57f730832592879f0be1c8be35)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the Locked Row/Column (locked-line) technique, registers it early in the technique chain, updates types, and extends tests to expect 25 techniques.
> 
> - **Logic/Techniques**:
>   - **New Technique**: Implement `locked-line` in `src/logic/techniques/lockedLine.ts` (places crosses when a region’s viable cells are locked to a single row/column).
>   - **Registration**: Add `locked-line` to `techniquesInOrder` (after `trivial-marks`) in `src/logic/techniques.ts`.
>   - **Types**: Extend `TechniqueId` with `locked-line` in `src/types/hints.ts`.
> - **Tests**:
>   - **New**: `tests/lockedLine.test.ts` covering row lock behavior and early ordering.
>   - **Integration/Ordering**: Update expectations to include `locked-line` and increase total techniques to `25` in `tests/integration.test.ts` and `tests/techniqueOrdering.test.ts` (order lists and counts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3299e01a16875c3662d9c57432858f29db2b902d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->