### PR TITLE
Add entanglement pattern calculator

### DIFF
--- a/entanglement-calculator/README.md
+++ b/entanglement-calculator/README.md
@@ -1,0 +1,19 @@
+# Entanglement pattern calculator
+
+This folder contains a standalone Node.js/TypeScript utility for enumerating entanglement-style rectangles that arise from placing `z` non-touching stars on an `x * x` grid. It enforces the usual Star Battle adjacency rule (no orthogonal or diagonal touching) and the requested `y` limit of stars per row/column.
+
+## Build
+
+```
+pnpm exec tsc -p entanglement-calculator/tsconfig.json
+```
+
+## Usage
+
+Run the compiled script and provide the grid parameters:
+
+```
+node entanglement-calculator/dist/index.js --gridSize=10 --starsPerLine=2 --entangledStars=2 --output=entanglement-calculator/output/10x10-2star-entanglements.json
+```
+
+Short aliases are supported (`--n`, `--y`, `--z`) along with an optional `--maxPatterns` limit to keep output files small. The script writes a JSON payload describing every pattern it found to the provided output path (creating parent directories when needed).

--- a/entanglement-calculator/dist/index.js
+++ b/entanglement-calculator/dist/index.js
@@ -1,0 +1,167 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs_1 = require("fs");
+const path_1 = require("path");
+function parseArgs(argv) {
+    const args = {};
+    for (const raw of argv.slice(2)) {
+        const [key, value] = raw.replace(/^--/, "").split("=");
+        if (!value)
+            continue;
+        const numeric = Number(value);
+        switch (key) {
+            case "gridSize":
+            case "n":
+                args.gridSize = numeric;
+                break;
+            case "starsPerLine":
+            case "y":
+                args.starsPerLine = numeric;
+                break;
+            case "entangledStars":
+            case "z":
+                args.entangledStars = numeric;
+                break;
+            case "output":
+                args.outputPath = value;
+                break;
+            case "maxPatterns":
+                args.maxPatterns = numeric;
+                break;
+            default:
+                console.warn(`Unknown argument ignored: ${raw}`);
+        }
+    }
+    if (!args.gridSize || !args.starsPerLine || !args.entangledStars) {
+        throw new Error("Missing required arguments. Usage: node dist/index.js --gridSize=10 --starsPerLine=2 --entangledStars=2 --output=path/to/file.json [--maxPatterns=500]");
+    }
+    args.outputPath = (0, path_1.resolve)(args.outputPath || "entanglement-calculator/output/entanglement-patterns.json");
+    return args;
+}
+function toKey({ row, col }) {
+    return `${row},${col}`;
+}
+function canPlace(star, starSet, n, rowCounts, colCounts, maxPerLine) {
+    if (rowCounts[star.row] >= maxPerLine || colCounts[star.col] >= maxPerLine) {
+        return false;
+    }
+    for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+            const key = toKey({ row: star.row + dr, col: star.col + dc });
+            if (starSet.has(key))
+                return false;
+        }
+    }
+    return star.row >= 0 && star.row < n && star.col >= 0 && star.col < n;
+}
+function computeForbiddenCells(n, stars) {
+    const forbidden = new Set();
+    for (const { row, col } of stars) {
+        for (let dr = -1; dr <= 1; dr++) {
+            for (let dc = -1; dc <= 1; dc++) {
+                const nr = row + dr;
+                const nc = col + dc;
+                if (nr < 0 || nr >= n || nc < 0 || nc >= n)
+                    continue;
+                const key = toKey({ row: nr, col: nc });
+                forbidden.add(key);
+            }
+        }
+    }
+    return forbidden;
+}
+function computeRectangle(n, stars) {
+    const rows = stars.map((s) => s.row);
+    const cols = stars.map((s) => s.col);
+    const top = Math.max(Math.min(...rows) - 1, 0);
+    const left = Math.max(Math.min(...cols) - 1, 0);
+    const bottom = Math.min(Math.max(...rows) + 1, n - 1);
+    const right = Math.min(Math.max(...cols) + 1, n - 1);
+    return { top, left, bottom, right };
+}
+function enumeratePatterns(args) {
+    const { gridSize: n, entangledStars: z, starsPerLine: maxPerLine, maxPatterns } = args;
+    const patterns = [];
+    const starSet = new Set();
+    const stars = [];
+    const rowCounts = Array(n).fill(0);
+    const colCounts = Array(n).fill(0);
+    const totalCells = n * n;
+    const remainingCells = (index) => totalCells - index;
+    function backtrack(startIndex) {
+        if (stars.length === z) {
+            const forbidden = computeForbiddenCells(n, stars);
+            const rectangle = computeRectangle(n, stars);
+            patterns.push({
+                id: patterns.length + 1,
+                stars: [...stars],
+                forbiddenCells: [...forbidden].map((key) => {
+                    const [row, col] = key.split(",").map(Number);
+                    return { row, col };
+                }).sort((a, b) => (a.row - b.row) || (a.col - b.col)),
+                rectangle,
+                coverage: {
+                    rectangleArea: (rectangle.bottom - rectangle.top + 1) * (rectangle.right - rectangle.left + 1),
+                    forbiddenCount: forbidden.size,
+                },
+            });
+            return;
+        }
+        if (maxPatterns !== undefined && patterns.length >= maxPatterns) {
+            return;
+        }
+        const slotsRemaining = z - stars.length;
+        for (let idx = startIndex; idx < totalCells; idx++) {
+            if (remainingCells(idx) < slotsRemaining)
+                break;
+            const row = Math.floor(idx / n);
+            const col = idx % n;
+            const candidate = { row, col };
+            if (!canPlace(candidate, starSet, n, rowCounts, colCounts, maxPerLine))
+                continue;
+            starSet.add(toKey(candidate));
+            stars.push(candidate);
+            rowCounts[row] += 1;
+            colCounts[col] += 1;
+            backtrack(idx + 1);
+            starSet.delete(toKey(candidate));
+            stars.pop();
+            rowCounts[row] -= 1;
+            colCounts[col] -= 1;
+            if (maxPatterns !== undefined && patterns.length >= maxPatterns) {
+                break;
+            }
+        }
+    }
+    backtrack(0);
+    return patterns;
+}
+function run() {
+    const args = parseArgs(process.argv);
+    const patterns = enumeratePatterns(args);
+    const payload = {
+        metadata: {
+            gridSize: args.gridSize,
+            starsPerLine: args.starsPerLine,
+            entangledStars: args.entangledStars,
+            maxPatterns: args.maxPatterns ?? null,
+            generatedAt: new Date().toISOString(),
+            description: "Automatically enumerated entanglement zones for non-touching star placements. Each pattern marks forbidden cells resulting from the adjacency rule and a bounding rectangle expanded by one cell around the stars.",
+        },
+        patternCount: patterns.length,
+        patterns,
+    };
+    const outputPath = args.outputPath;
+    (0, fs_1.mkdirSync)((0, path_1.dirname)(outputPath), { recursive: true });
+    (0, fs_1.writeFileSync)(outputPath, JSON.stringify(payload, null, 2), "utf8");
+    console.log(`Wrote ${patterns.length} entanglement pattern(s) to ${outputPath}`);
+}
+if (require.main === module) {
+    try {
+        run();
+    }
+    catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}

--- a/entanglement-calculator/output/sample-entanglements.json
+++ b/entanglement-calculator/output/sample-entanglements.json
@@ -1,0 +1,3447 @@
+{
+  "metadata": {
+    "gridSize": 4,
+    "starsPerLine": 1,
+    "entangledStars": 2,
+    "maxPatterns": 50,
+    "generatedAt": "2025-12-04T07:28:53.457Z",
+    "description": "Automatically enumerated entanglement zones for non-touching star placements. Each pattern marks forbidden cells resulting from the adjacency rule and a bounding rectangle expanded by one cell around the stars."
+  },
+  "patternCount": 50,
+  "patterns": [
+    {
+      "id": 1,
+      "stars": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 2,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 2,
+      "stars": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 2,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 3,
+      "stars": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 2
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 4,
+      "stars": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 12
+      }
+    },
+    {
+      "id": 5,
+      "stars": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 6,
+      "stars": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 2
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 7,
+      "stars": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 8,
+      "stars": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 8
+      }
+    },
+    {
+      "id": 9,
+      "stars": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 2,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 10,
+      "stars": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 2
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 11,
+      "stars": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 13
+      }
+    },
+    {
+      "id": 12,
+      "stars": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 13,
+      "stars": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 2
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 14,
+      "stars": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 12
+      }
+    },
+    {
+      "id": 15,
+      "stars": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 16,
+      "stars": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 2,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 17,
+      "stars": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 18,
+      "stars": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 13
+      }
+    },
+    {
+      "id": 19,
+      "stars": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 1,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 20,
+      "stars": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 21,
+      "stars": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 12
+      }
+    },
+    {
+      "id": 22,
+      "stars": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 1,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 23,
+      "stars": [
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 2,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 24,
+      "stars": [
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 2,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 25,
+      "stars": [
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 26,
+      "stars": [
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 12
+      }
+    },
+    {
+      "id": 27,
+      "stars": [
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 1,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 28,
+      "stars": [
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 8
+      }
+    },
+    {
+      "id": 29,
+      "stars": [
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 30,
+      "stars": [
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 1,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 31,
+      "stars": [
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 13
+      }
+    },
+    {
+      "id": 32,
+      "stars": [
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 12
+      }
+    },
+    {
+      "id": 33,
+      "stars": [
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 2
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 34,
+      "stars": [
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 35,
+      "stars": [
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 36,
+      "stars": [
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 13
+      }
+    },
+    {
+      "id": 37,
+      "stars": [
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 2
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 38,
+      "stars": [
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 13
+      }
+    },
+    {
+      "id": 39,
+      "stars": [
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 0
+        },
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 12
+      }
+    },
+    {
+      "id": 40,
+      "stars": [
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 13
+      }
+    },
+    {
+      "id": 41,
+      "stars": [
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 12
+      }
+    },
+    {
+      "id": 42,
+      "stars": [
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 13
+      }
+    },
+    {
+      "id": 43,
+      "stars": [
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 1
+        },
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 1,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 44,
+      "stars": [
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 12
+      }
+    },
+    {
+      "id": 45,
+      "stars": [
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 13
+      }
+    },
+    {
+      "id": 46,
+      "stars": [
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 47,
+      "stars": [
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 16,
+        "forbiddenCount": 11
+      }
+    },
+    {
+      "id": 48,
+      "stars": [
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 0,
+          "col": 2
+        },
+        {
+          "row": 0,
+          "col": 3
+        },
+        {
+          "row": 1,
+          "col": 2
+        },
+        {
+          "row": 1,
+          "col": 3
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 0,
+        "left": 1,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 49,
+      "stars": [
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 2
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 1,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    },
+    {
+      "id": 50,
+      "stars": [
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "forbiddenCells": [
+        {
+          "row": 1,
+          "col": 0
+        },
+        {
+          "row": 1,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 0
+        },
+        {
+          "row": 2,
+          "col": 1
+        },
+        {
+          "row": 2,
+          "col": 2
+        },
+        {
+          "row": 2,
+          "col": 3
+        },
+        {
+          "row": 3,
+          "col": 0
+        },
+        {
+          "row": 3,
+          "col": 1
+        },
+        {
+          "row": 3,
+          "col": 2
+        },
+        {
+          "row": 3,
+          "col": 3
+        }
+      ],
+      "rectangle": {
+        "top": 1,
+        "left": 0,
+        "bottom": 3,
+        "right": 3
+      },
+      "coverage": {
+        "rectangleArea": 12,
+        "forbiddenCount": 10
+      }
+    }
+  ]
+}

--- a/entanglement-calculator/src/index.ts
+++ b/entanglement-calculator/src/index.ts
@@ -1,0 +1,216 @@
+import { writeFileSync, mkdirSync } from "fs";
+import { dirname, resolve } from "path";
+
+interface Coordinate {
+  row: number;
+  col: number;
+}
+
+interface Rectangle {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+}
+
+interface EntanglementPattern {
+  id: number;
+  stars: Coordinate[];
+  forbiddenCells: Coordinate[];
+  rectangle: Rectangle;
+  coverage: {
+    rectangleArea: number;
+    forbiddenCount: number;
+  };
+}
+
+interface CalculatorArgs {
+  gridSize: number;
+  starsPerLine: number;
+  entangledStars: number;
+  outputPath: string;
+  maxPatterns?: number;
+}
+
+function parseArgs(argv: string[]): CalculatorArgs {
+  const args: Partial<CalculatorArgs> = {};
+
+  for (const raw of argv.slice(2)) {
+    const [key, value] = raw.replace(/^--/, "").split("=");
+    if (!value) continue;
+    const numeric = Number(value);
+    switch (key) {
+      case "gridSize":
+      case "n":
+        args.gridSize = numeric;
+        break;
+      case "starsPerLine":
+      case "y":
+        args.starsPerLine = numeric;
+        break;
+      case "entangledStars":
+      case "z":
+        args.entangledStars = numeric;
+        break;
+      case "output":
+        args.outputPath = value;
+        break;
+      case "maxPatterns":
+        args.maxPatterns = numeric;
+        break;
+      default:
+        console.warn(`Unknown argument ignored: ${raw}`);
+    }
+  }
+
+  if (!args.gridSize || !args.starsPerLine || !args.entangledStars) {
+    throw new Error(
+      "Missing required arguments. Usage: node dist/index.js --gridSize=10 --starsPerLine=2 --entangledStars=2 --output=path/to/file.json [--maxPatterns=500]",
+    );
+  }
+
+  args.outputPath = resolve(args.outputPath || "entanglement-calculator/output/entanglement-patterns.json");
+
+  return args as CalculatorArgs;
+}
+
+function toKey({ row, col }: Coordinate): string {
+  return `${row},${col}`;
+}
+
+function canPlace(star: Coordinate, starSet: Set<string>, n: number, rowCounts: number[], colCounts: number[], maxPerLine: number): boolean {
+  if (rowCounts[star.row] >= maxPerLine || colCounts[star.col] >= maxPerLine) {
+    return false;
+  }
+  for (let dr = -1; dr <= 1; dr++) {
+    for (let dc = -1; dc <= 1; dc++) {
+      const key = toKey({ row: star.row + dr, col: star.col + dc });
+      if (starSet.has(key)) return false;
+    }
+  }
+  return star.row >= 0 && star.row < n && star.col >= 0 && star.col < n;
+}
+
+function computeForbiddenCells(n: number, stars: Coordinate[]): Set<string> {
+  const forbidden = new Set<string>();
+  for (const { row, col } of stars) {
+    for (let dr = -1; dr <= 1; dr++) {
+      for (let dc = -1; dc <= 1; dc++) {
+        const nr = row + dr;
+        const nc = col + dc;
+        if (nr < 0 || nr >= n || nc < 0 || nc >= n) continue;
+        const key = toKey({ row: nr, col: nc });
+        forbidden.add(key);
+      }
+    }
+  }
+  return forbidden;
+}
+
+function computeRectangle(n: number, stars: Coordinate[]): Rectangle {
+  const rows = stars.map((s) => s.row);
+  const cols = stars.map((s) => s.col);
+  const top = Math.max(Math.min(...rows) - 1, 0);
+  const left = Math.max(Math.min(...cols) - 1, 0);
+  const bottom = Math.min(Math.max(...rows) + 1, n - 1);
+  const right = Math.min(Math.max(...cols) + 1, n - 1);
+  return { top, left, bottom, right };
+}
+
+function enumeratePatterns(args: CalculatorArgs): EntanglementPattern[] {
+  const { gridSize: n, entangledStars: z, starsPerLine: maxPerLine, maxPatterns } = args;
+  const patterns: EntanglementPattern[] = [];
+  const starSet = new Set<string>();
+  const stars: Coordinate[] = [];
+  const rowCounts = Array(n).fill(0);
+  const colCounts = Array(n).fill(0);
+  const totalCells = n * n;
+
+  const remainingCells = (index: number) => totalCells - index;
+
+  function backtrack(startIndex: number) {
+    if (stars.length === z) {
+      const forbidden = computeForbiddenCells(n, stars);
+      const rectangle = computeRectangle(n, stars);
+      patterns.push({
+        id: patterns.length + 1,
+        stars: [...stars],
+        forbiddenCells: [...forbidden].map((key) => {
+          const [row, col] = key.split(",").map(Number);
+          return { row, col };
+        }).sort((a, b) => (a.row - b.row) || (a.col - b.col)),
+        rectangle,
+        coverage: {
+          rectangleArea: (rectangle.bottom - rectangle.top + 1) * (rectangle.right - rectangle.left + 1),
+          forbiddenCount: forbidden.size,
+        },
+      });
+      return;
+    }
+
+    if (maxPatterns !== undefined && patterns.length >= maxPatterns) {
+      return;
+    }
+
+    const slotsRemaining = z - stars.length;
+    for (let idx = startIndex; idx < totalCells; idx++) {
+      if (remainingCells(idx) < slotsRemaining) break;
+      const row = Math.floor(idx / n);
+      const col = idx % n;
+      const candidate: Coordinate = { row, col };
+      if (!canPlace(candidate, starSet, n, rowCounts, colCounts, maxPerLine)) continue;
+
+      starSet.add(toKey(candidate));
+      stars.push(candidate);
+      rowCounts[row] += 1;
+      colCounts[col] += 1;
+
+      backtrack(idx + 1);
+
+      starSet.delete(toKey(candidate));
+      stars.pop();
+      rowCounts[row] -= 1;
+      colCounts[col] -= 1;
+
+      if (maxPatterns !== undefined && patterns.length >= maxPatterns) {
+        break;
+      }
+    }
+  }
+
+  backtrack(0);
+  return patterns;
+}
+
+function run(): void {
+  const args = parseArgs(process.argv);
+  const patterns = enumeratePatterns(args);
+  const payload = {
+    metadata: {
+      gridSize: args.gridSize,
+      starsPerLine: args.starsPerLine,
+      entangledStars: args.entangledStars,
+      maxPatterns: args.maxPatterns ?? null,
+      generatedAt: new Date().toISOString(),
+      description:
+        "Automatically enumerated entanglement zones for non-touching star placements. Each pattern marks forbidden cells resulting from the adjacency rule and a bounding rectangle expanded by one cell around the stars.",
+    },
+    patternCount: patterns.length,
+    patterns,
+  };
+
+  const outputPath = args.outputPath;
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(payload, null, 2), "utf8");
+  console.log(`Wrote ${patterns.length} entanglement pattern(s) to ${outputPath}`);
+}
+
+if (require.main === module) {
+  try {
+    run();
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
+  }
+}
+

--- a/entanglement-calculator/tsconfig.json
+++ b/entanglement-calculator/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "vue": "^3.5.0"
   },
   "devDependencies": {
+    "@types/node": "^22.7.4",
     "@vitejs/plugin-vue": "^5.0.0",
     "fast-check": "^4.3.0",
     "jsdom": "^27.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,12 @@ importers:
         specifier: ^3.5.0
         version: 3.5.25(typescript@5.9.3)
     devDependencies:
+      '@types/node':
+        specifier: ^22.7.4
+        version: 22.19.1
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
-        version: 5.2.4(vite@5.4.21)(vue@3.5.25(typescript@5.9.3))
+        version: 5.2.4(vite@5.4.21(@types/node@22.19.1))(vue@3.5.25(typescript@5.9.3))
       fast-check:
         specifier: ^4.3.0
         version: 4.3.0
@@ -26,10 +29,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.0.0
-        version: 5.4.21
+        version: 5.4.21(@types/node@22.19.1)
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(jsdom@27.2.0)
+        version: 2.1.9(@types/node@22.19.1)(jsdom@27.2.0)
       vue-tsc:
         specifier: ^2.0.0
         version: 2.2.12(typescript@5.9.3)
@@ -350,6 +353,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.1':
+    resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
 
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
@@ -694,6 +700,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -1012,9 +1021,13 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.25(typescript@5.9.3))':
+  '@types/node@22.19.1':
     dependencies:
-      vite: 5.4.21
+      undici-types: 6.21.0
+
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@22.19.1))(vue@3.5.25(typescript@5.9.3))':
+    dependencies:
+      vite: 5.4.21(@types/node@22.19.1)
       vue: 3.5.25(typescript@5.9.3)
 
   '@vitest/expect@2.1.9':
@@ -1024,13 +1037,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21)':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.1))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@22.19.1)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -1411,13 +1424,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  vite-node@2.1.9:
+  undici-types@6.21.0: {}
+
+  vite-node@2.1.9(@types/node@22.19.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@22.19.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1429,18 +1444,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@22.19.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.53.3
     optionalDependencies:
+      '@types/node': 22.19.1
       fsevents: 2.3.3
 
-  vitest@2.1.9(jsdom@27.2.0):
+  vitest@2.1.9(@types/node@22.19.1)(jsdom@27.2.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21)
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -1456,10 +1472,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21
-      vite-node: 2.1.9
+      vite: 5.4.21(@types/node@22.19.1)
+      vite-node: 2.1.9(@types/node@22.19.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 22.19.1
       jsdom: 27.2.0
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
## Summary
- add a standalone entanglement-pattern calculator that enumerates non-touching star placements and their forbidden zones for configurable grids
- document how to build and run the tool and include a minimal sample JSON output
- add Node type definitions so the calculator builds cleanly

## Testing
- pnpm exec tsc -p entanglement-calculator/tsconfig.json
- pnpm test -- --reporter=basic *(terminated in the container environment before completing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931375d0d7083258d4945f1d7c82237)