### PR TITLE
Add stats layer and subset constraint squeeze

### DIFF
--- a/src/logic/stats.ts
+++ b/src/logic/stats.ts
@@ -1,0 +1,230 @@
+import type { PuzzleState, Coords } from '../types/puzzle';
+import {
+  colCells,
+  countStars,
+  emptyCells,
+  formatCol,
+  formatRegion,
+  formatRow,
+  regionCells,
+  rowCells,
+} from './helpers';
+
+export type ConstraintSource =
+  | 'row'
+  | 'col'
+  | 'region'
+  | 'region-band'
+  | 'block';
+
+export interface Constraint {
+  cells: Coords[];
+  minStars: number;
+  maxStars: number;
+  source: ConstraintSource;
+  description: string;
+}
+
+export interface Stats {
+  rowConstraints: Constraint[];
+  colConstraints: Constraint[];
+  regionConstraints: Constraint[];
+  regionBandConstraints: Constraint[];
+  blockConstraints: Constraint[];
+}
+
+const coordKey = (c: Coords) => `${c.row},${c.col}`;
+
+function normalizeBounds(minStars: number, maxStars: number): { minStars: number; maxStars: number } {
+  const min = Math.max(0, minStars);
+  const max = Math.max(min, maxStars);
+  return { minStars: min, maxStars: max };
+}
+
+function rowConstraint(state: PuzzleState, row: number): Constraint {
+  const candidates = emptyCells(state, rowCells(state, row));
+  const placedStars = countStars(state, rowCells(state, row));
+  const remaining = state.def.starsPerUnit - placedStars;
+  const { minStars, maxStars } = normalizeBounds(remaining, Math.min(remaining, candidates.length));
+
+  return {
+    cells: candidates,
+    minStars,
+    maxStars,
+    source: 'row',
+    description: `${formatRow(row)} (${remaining} star${remaining === 1 ? '' : 's'} remaining)`,
+  };
+}
+
+function colConstraint(state: PuzzleState, col: number): Constraint {
+  const candidates = emptyCells(state, colCells(state, col));
+  const placedStars = countStars(state, colCells(state, col));
+  const remaining = state.def.starsPerUnit - placedStars;
+  const { minStars, maxStars } = normalizeBounds(remaining, Math.min(remaining, candidates.length));
+
+  return {
+    cells: candidates,
+    minStars,
+    maxStars,
+    source: 'col',
+    description: `${formatCol(col)} (${remaining} star${remaining === 1 ? '' : 's'} remaining)`,
+  };
+}
+
+function regionConstraint(state: PuzzleState, regionId: number): Constraint {
+  const cells = regionCells(state, regionId);
+  const candidates = emptyCells(state, cells);
+  const placedStars = countStars(state, cells);
+  const remaining = state.def.starsPerUnit - placedStars;
+  const { minStars, maxStars } = normalizeBounds(remaining, Math.min(remaining, candidates.length));
+
+  return {
+    cells: candidates,
+    minStars,
+    maxStars,
+    source: 'region',
+    description: `Region ${formatRegion(regionId)} (${remaining} star${remaining === 1 ? '' : 's'} remaining)`,
+  };
+}
+
+function collectRegionBandConstraints(state: PuzzleState, regionId: number): Constraint[] {
+  const cells = regionCells(state, regionId);
+  const rows = new Set(cells.map((c) => c.row));
+  const sortedRows = Array.from(rows).sort((a, b) => a - b);
+  const constraints: Constraint[] = [];
+
+  for (let i = 0; i < sortedRows.length; i += 1) {
+    for (let j = i; j < sortedRows.length; j += 1) {
+      // Only consider contiguous bands of rows to avoid overly broad combinations
+      if (sortedRows[j] - sortedRows[i] !== j - i) continue;
+
+      const startRow = sortedRows[i];
+      const endRow = sortedRows[j];
+      const bandCells = cells.filter((c) => c.row >= startRow && c.row <= endRow);
+      const bandCandidates = emptyCells(state, bandCells);
+      const outsideCells = cells.filter((c) => c.row < startRow || c.row > endRow);
+      const outsideCandidates = emptyCells(state, outsideCells);
+
+      const placedStars = countStars(state, cells);
+      const remaining = state.def.starsPerUnit - placedStars;
+      const maxOutsideCapacity = outsideCandidates.length;
+      const minStars = Math.max(0, remaining - maxOutsideCapacity);
+      const maxStars = Math.min(remaining, bandCandidates.length);
+      const bounds = normalizeBounds(minStars, maxStars);
+
+      constraints.push({
+        cells: bandCandidates,
+        minStars: bounds.minStars,
+        maxStars: bounds.maxStars,
+        source: 'region-band',
+        description: `Region ${formatRegion(regionId)} rows ${startRow}–${endRow}`,
+      });
+    }
+  }
+
+  return constraints;
+}
+
+function blockConstraints(state: PuzzleState): Constraint[] {
+  const constraints: Constraint[] = [];
+  for (let r = 0; r < state.def.size - 1; r += 1) {
+    for (let c = 0; c < state.def.size - 1; c += 1) {
+      const block: Coords[] = [
+        { row: r, col: c },
+        { row: r, col: c + 1 },
+        { row: r + 1, col: c },
+        { row: r + 1, col: c + 1 },
+      ];
+
+      const candidates = emptyCells(state, block);
+      const starsInBlock = countStars(state, block);
+      const maxStars = Math.max(0, 1 - starsInBlock);
+      const { minStars } = normalizeBounds(0, maxStars);
+
+      constraints.push({
+        cells: candidates,
+        minStars,
+        maxStars,
+        source: 'block',
+        description: `2×2 block at rows ${r}–${r + 1}, cols ${c}–${c + 1}`,
+      });
+    }
+  }
+  return constraints;
+}
+
+export function computeStats(state: PuzzleState): Stats {
+  const rowConstraints = Array.from({ length: state.def.size }, (_, r) => rowConstraint(state, r));
+  const colConstraints = Array.from({ length: state.def.size }, (_, c) => colConstraint(state, c));
+  const regionConstraints = Array.from({ length: state.def.size }, (_, id) => regionConstraint(state, id + 1));
+  const regionBandConstraints = regionConstraints
+    .map((_, idx) => collectRegionBandConstraints(state, idx + 1))
+    .flat();
+  const blockConstraintsList = blockConstraints(state);
+
+  return {
+    rowConstraints,
+    colConstraints,
+    regionConstraints,
+    regionBandConstraints,
+    blockConstraints: blockConstraintsList,
+  };
+}
+
+export function allConstraints(stats: Stats): Constraint[] {
+  return [
+    ...stats.rowConstraints,
+    ...stats.colConstraints,
+    ...stats.regionConstraints,
+    ...stats.regionBandConstraints,
+    ...stats.blockConstraints,
+  ];
+}
+
+function isSubset(smaller: Constraint, larger: Constraint): boolean {
+  if (smaller.cells.length === 0) return false;
+  const largeSet = new Set(larger.cells.map(coordKey));
+  return smaller.cells.every((c) => largeSet.has(coordKey(c)));
+}
+
+function differenceCells(a: Constraint, b: Constraint): Coords[] {
+  const bSet = new Set(b.cells.map(coordKey));
+  return a.cells.filter((c) => !bSet.has(coordKey(c)));
+}
+
+export interface SubsetSqueezeResult {
+  eliminations: Coords[];
+  small: Constraint;
+  large: Constraint;
+}
+
+export function findSubsetConstraintSqueeze(state: PuzzleState): SubsetSqueezeResult | null {
+  const stats = computeStats(state);
+  const constraints = allConstraints(stats);
+
+  for (const small of constraints) {
+    for (const large of constraints) {
+      if (small === large) continue;
+      if (!isSubset(small, large)) continue;
+      if (small.minStars === 0) continue;
+      if (small.minStars !== large.maxStars) continue;
+
+      const eliminations: Coords[] = [];
+      const diff = differenceCells(large, small);
+      for (const cell of diff) {
+        if (state.cells[cell.row][cell.col] === 'empty') {
+          eliminations.push(cell);
+        }
+      }
+      if (eliminations.length > 0) {
+        return { eliminations, small, large };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function describeConstraintPair(small: Constraint, large: Constraint): string {
+  return `${small.description} can account for all ${large.maxStars} star(s) allowed by ${large.description}`;
+}

--- a/src/logic/techniques.ts
+++ b/src/logic/techniques.ts
@@ -30,6 +30,7 @@ import { findFishHint } from './techniques/fish';
 import { findNRooksHint } from './techniques/nRooks';
 import { findEntanglementHint } from './techniques/entanglement';
 import { findPatternMatchingHint } from './techniques/patternMatching';
+import { findSubsetConstraintSqueezeHint } from './techniques/subsetConstraintSqueeze';
 
 export interface Technique {
   id: TechniqueId;
@@ -137,6 +138,11 @@ export const techniquesInOrder: Technique[] = [
     id: 'set-differentials',
     name: 'Set Differentials',
     findHint: findSetDifferentialsHint,
+  },
+  {
+    id: 'subset-constraint-squeeze',
+    name: 'Subset Constraint Squeeze',
+    findHint: findSubsetConstraintSqueezeHint,
   },
   {
     id: 'at-sea',

--- a/src/logic/techniques/subsetConstraintSqueeze.ts
+++ b/src/logic/techniques/subsetConstraintSqueeze.ts
@@ -1,0 +1,26 @@
+import type { PuzzleState } from '../../types/puzzle';
+import type { Hint } from '../../types/hints';
+import { describeConstraintPair, findSubsetConstraintSqueeze } from '../stats';
+
+let hintCounter = 0;
+function nextHintId() {
+  hintCounter += 1;
+  return `subset-squeeze-${hintCounter}`;
+}
+
+export function findSubsetConstraintSqueezeHint(state: PuzzleState): Hint | null {
+  const result = findSubsetConstraintSqueeze(state);
+  if (!result) return null;
+
+  return {
+    id: nextHintId(),
+    kind: 'place-cross',
+    technique: 'subset-constraint-squeeze',
+    resultCells: result.eliminations,
+    explanation: `Subset constraint squeeze: ${describeConstraintPair(result.small, result.large)}. Cells outside the smaller constraint cannot contain stars.`,
+    highlights: {
+      cells: [...result.small.cells, ...result.eliminations],
+    },
+  };
+}
+

--- a/src/types/hints.ts
+++ b/src/types/hints.ts
@@ -33,7 +33,8 @@ export type TechniqueId =
   | 'fish'
   | 'n-rooks'
   | 'entanglement'
-  | 'pattern-matching';
+  | 'pattern-matching'
+  | 'subset-constraint-squeeze';
 
 export type HintKind = 'place-star' | 'place-cross';
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -941,7 +941,7 @@ describe('Integration Tests: Guide Example Sequences', () => {
 });
 
 describe('Integration Tests: Technique Verification', () => {
-  it('verifies all 28 techniques are registered', () => {
+  it('verifies all techniques are registered', () => {
     const expectedTechniques: TechniqueId[] = [
       'trivial-marks',
       'locked-line',
@@ -962,6 +962,7 @@ describe('Integration Tests: Technique Verification', () => {
       'composite-shapes',
       'squeeze',
       'set-differentials',
+      'subset-constraint-squeeze',
       'at-sea',
       'kissing-ls',
       'the-m',
@@ -974,7 +975,7 @@ describe('Integration Tests: Technique Verification', () => {
       'by-a-thread-at-sea',
     ];
 
-    expect(techniquesInOrder.length).toBe(29);
+    expect(techniquesInOrder.length).toBe(30);
     
     const registeredIds = techniquesInOrder.map(t => t.id);
     
@@ -1004,6 +1005,7 @@ describe('Integration Tests: Technique Verification', () => {
       'composite-shapes',
       'squeeze',
       'set-differentials',
+      'subset-constraint-squeeze',
       'at-sea',
       'kissing-ls',
       'the-m',

--- a/tests/statsFeature.test.ts
+++ b/tests/statsFeature.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { computeStats } from '../src/logic/stats';
+import { createEmptyPuzzleState, type PuzzleDef, type PuzzleState } from '../src/types/puzzle';
+import { findSubsetConstraintSqueezeHint } from '../src/logic/techniques/subsetConstraintSqueeze';
+
+function makeSmallState(): PuzzleState {
+  const def: PuzzleDef = {
+    size: 2,
+    starsPerUnit: 1,
+    regions: [
+      [1, 1],
+      [2, 2],
+    ],
+  };
+  return createEmptyPuzzleState(def);
+}
+
+describe('stats layer', () => {
+  it('computes row/col/region constraints with remaining quotas', () => {
+    const state = makeSmallState();
+    const stats = computeStats(state);
+
+    expect(stats.rowConstraints).toHaveLength(2);
+    expect(stats.colConstraints).toHaveLength(2);
+    expect(stats.regionConstraints).toHaveLength(2);
+
+    expect(stats.rowConstraints[0].minStars).toBe(1);
+    expect(stats.rowConstraints[0].maxStars).toBe(1);
+    expect(stats.colConstraints[1].minStars).toBe(1);
+    expect(stats.regionConstraints[0].minStars).toBe(1);
+  });
+});
+
+describe('subset constraint squeeze', () => {
+  it('eliminates cells outside a fully-accounted constraint subset', () => {
+    const state = makeSmallState();
+
+    // Block the bottom-left cell so the first column can only place a star in (0,0)
+    state.cells[1][0] = 'cross';
+
+    const hint = findSubsetConstraintSqueezeHint(state);
+
+    expect(hint).not.toBeNull();
+    expect(hint?.kind).toBe('place-cross');
+    expect(hint?.resultCells).toEqual([{ row: 0, col: 1 }]);
+    expect(hint?.explanation).toContain('Subset constraint squeeze');
+  });
+});
+

--- a/tests/techniqueOrdering.test.ts
+++ b/tests/techniqueOrdering.test.ts
@@ -28,6 +28,7 @@ describe('Technique Ordering', () => {
       'composite-shapes',
       'squeeze',
       'set-differentials',
+      'subset-constraint-squeeze',
       'at-sea',
       'kissing-ls',
       'the-m',
@@ -65,6 +66,7 @@ describe('Technique Ordering', () => {
       'composite-shapes',
       'squeeze',
       'set-differentials',
+      'subset-constraint-squeeze',
       'at-sea',
       'kissing-ls',
       'the-m',
@@ -84,8 +86,8 @@ describe('Technique Ordering', () => {
     }
   });
 
-  it('should have exactly 29 techniques registered', () => {
-    expect(techniquesInOrder).toHaveLength(29);
+  it('should have exactly 30 techniques registered', () => {
+    expect(techniquesInOrder).toHaveLength(30);
   });
 
   it('should have unique technique IDs', () => {


### PR DESCRIPTION
## Summary
- add a stats layer that derives reusable constraints for rows, columns, regions, bands, and 2×2 blocks
- implement a subset constraint squeeze technique built on the shared constraint representation
- add focused tests and update technique ordering expectations to cover the new capability

## Testing
- Not run (npm tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933414b18e48325b8963f05114edf45)