### PR TITLE
Remove hint search delay and transition

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,30 +54,7 @@ const showEntanglementViewer = ref(false);
 const selectedPatternId = ref<string | null>(null);
 const showTechniqueManager = ref(false);
 
-// Delayed visibility for thinking indicator to prevent flickering
-const showThinkingIndicator = ref(false);
-let thinkingTimeout: ReturnType<typeof setTimeout> | null = null;
-const MIN_THINKING_DISPLAY_MS = 300; // Minimum time to show indicator
-
-// Watch isThinking and manage delayed visibility
-watch(() => store.isThinking, (isThinking) => {
-  // Clear any existing timeout
-  if (thinkingTimeout) {
-    clearTimeout(thinkingTimeout);
-    thinkingTimeout = null;
-  }
-
-  if (isThinking) {
-    // Show immediately when thinking starts
-    showThinkingIndicator.value = true;
-  } else {
-    // Delay hiding to prevent flicker
-    thinkingTimeout = setTimeout(() => {
-      showThinkingIndicator.value = false;
-      thinkingTimeout = null;
-    }, MIN_THINKING_DISPLAY_MS);
-  }
-}, { immediate: true });
+const showThinkingIndicator = computed(() => store.isThinking);
 
 const regionThemeOptions: Array<{ value: RegionTheme; label: string }> = [
   { value: 'default', label: 'Default' },
@@ -476,11 +453,6 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  // Clean up thinking indicator timeout
-  if (thinkingTimeout) {
-    clearTimeout(thinkingTimeout);
-    thinkingTimeout = null;
-  }
   window.removeEventListener('keydown', handleKeyDown);
 });
 
@@ -699,15 +671,13 @@ watch(
           :result-cells="store.currentHint?.resultCells ?? []" :show-row-col-numbers="store.showRowColNumbers"
           :show-area-labels="store.showAreaLabels || !!store.currentHint" :violations="violations" mode="play"
           @cell-click="onCellClick" />
-        <Transition name="thinking-fade">
-          <div v-if="showThinkingIndicator" class="thinking-indicator">
-            <div class="thinking-spinner"></div>
-            <span>
-              <template v-if="store.currentTechnique">Testing {{ store.currentTechnique }}...</template>
-              <template v-else>Looking for hint...</template>
-            </span>
-          </div>
-        </Transition>
+        <div v-if="showThinkingIndicator" class="thinking-indicator">
+          <div class="thinking-spinner"></div>
+          <span>
+            <template v-if="store.currentTechnique">Testing {{ store.currentTechnique }}...</template>
+            <template v-else>Looking for hint...</template>
+          </span>
+        </div>
         <div v-if="isPuzzleComplete(store.puzzle)" class="completion-status">
           Puzzle complete
         </div>

--- a/src/style.css
+++ b/src/style.css
@@ -1589,22 +1589,6 @@ body {
   position: relative;
 }
 
-/* Transition animations for thinking indicator */
-.thinking-fade-enter-active,
-.thinking-fade-leave-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-
-.thinking-fade-enter-from {
-  opacity: 0;
-  transform: translateY(-0.5rem);
-}
-
-.thinking-fade-leave-to {
-  opacity: 0;
-  transform: translateY(-0.5rem);
-}
-
 .thinking-spinner {
   width: 1rem;
   height: 1rem;


### PR DESCRIPTION
## Summary
- simplify the thinking indicator to track solver activity directly without delayed visibility
- remove the transition wrapper and related CSS so the "Looking for hint" box appears immediately

## Testing
- npm test *(fails: existing suite has numerous failing tests; run interrupted after many failures)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407c2a690883258a954cc647cd87e6)