### PR TITLE
Fix CI: upgrade pnpm from v8 to v10 to match lockfile version 9.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
pnpm v8 uses lockfile version 6.0 and cannot read the project's lockfile
(version 9.0), causing pnpm install to fail on every CI run.