### PR TITLE
fix: guard 2x2 forced-cross deduction against false positives in 5+ cell regions

### DIFF
--- a/src/logic/techniques/simpleShapes.ts
+++ b/src/logic/techniques/simpleShapes.ts
@@ -165,6 +165,14 @@ export function findSimpleShapesHint(state: PuzzleState): Hint | null {
     // Strategy: Check all 2×2 blocks that include cells from the shape.
     // If a 2×2 block contains 3 cells from the shape, the 4th cell cannot contain a star
     // (would violate 2×2 rule since shape must have 2 stars in 2★).
+    //
+    // IMPORTANT: This deduction is only valid when at least one of the 3 block cells
+    // must be a star. That is guaranteed only when the shape cells outside the block
+    // cannot hold all required stars on their own. For ≤4-cell regions this is always
+    // true by pigeonhole, but for larger regions we must verify it explicitly.
+    const regionStarCount = countStars(state, shapeCells);
+    const remainingStars = starsPerUnit - regionStarCount;
+
     for (let r = 0; r < size - 1; r++) {
       for (let c = 0; c < size - 1; c++) {
         const block: Coords[] = [
@@ -179,8 +187,21 @@ export function findSimpleShapesHint(state: PuzzleState): Hint | null {
           shapeCells.some(sc => sc.row === b.row && sc.col === b.col)
         );
 
-        // If 3 shape cells are in this 2×2 block, the 4th cell cannot have a star
+        // If 3 shape cells are in this 2×2 block, the 4th cell cannot have a star —
+        // but only if at least one star is guaranteed to land in the 3-cell block subset.
         if (shapeCellsInBlock.length === 3) {
+          // Shape cells outside this 2×2 block that can still hold a star.
+          const outsideCells = shapeCells.filter(sc =>
+            !block.some(b => b.row === sc.row && b.col === sc.col) &&
+            state.cells[sc.row][sc.col] !== 'cross'
+          );
+
+          // If the remaining stars can all be placed in the outside cells (non-adjacently),
+          // no star is forced into the 3-cell block and the 4th cell is not a forced cross.
+          if (canPlaceNonAdjacentStars(outsideCells, remainingStars)) {
+            continue;
+          }
+
           const fourthCell = block.find(b =>
             !shapeCells.some(sc => sc.row === b.row && sc.col === b.col)
           );
@@ -540,6 +561,22 @@ export function findSimpleShapesHint(state: PuzzleState): Hint | null {
   }
 
   return null;
+}
+
+/**
+ * Returns true if `count` mutually non-adjacent stars can be placed among `cells`.
+ * Uses simple backtracking; cells is typically small (≤ a few cells).
+ */
+function canPlaceNonAdjacentStars(cells: Coords[], count: number): boolean {
+  if (count === 0) return true;
+  if (cells.length < count) return false;
+  for (let i = 0; i < cells.length; i++) {
+    const nonAdj = cells.slice(i + 1).filter(c =>
+      Math.abs(c.row - cells[i].row) > 1 || Math.abs(c.col - cells[i].col) > 1
+    );
+    if (canPlaceNonAdjacentStars(nonAdj, count - 1)) return true;
+  }
+  return false;
 }
 
 /**

--- a/tests/simpleShapes.test.ts
+++ b/tests/simpleShapes.test.ts
@@ -64,4 +64,91 @@ describe('simple-shapes technique – 1×4 / 4×1 regions', () => {
   });
 });
 
+describe('simple-shapes technique – 5-cell P-pentomino forced-cross bug', () => {
+  /**
+   * Regression test for the false deduction in a 5-cell region.
+   *
+   * Region G (id=7) is a P-pentomino:
+   *   (3,6), (4,6), (4,7), (5,7), (5,8)
+   *
+   * (4,6) and (4,7) are already marked as crosses.
+   *
+   * The 2×2 block at rows 4–5, cols 6–7 contains 3 shape cells:
+   *   {(4,6), (4,7), (5,7)}.
+   * The 4th cell (5,6) is NOT in the region.
+   *
+   * The old code incorrectly forced (5,6) as a cross, but a valid star
+   * placement exists: stars at (3,6) and (5,8), neither in the 2×2 block.
+   */
+  function makePPentominoDef(): PuzzleDef {
+    // Fill everything with region 1 (background), then carve out region 7.
+    const regions: number[][] = Array.from({ length: DEFAULT_SIZE }, () =>
+      Array(DEFAULT_SIZE).fill(1),
+    );
+    // Region 7: P-pentomino cells
+    regions[3][6] = 7;
+    regions[4][6] = 7;
+    regions[4][7] = 7;
+    regions[5][7] = 7;
+    regions[5][8] = 7;
+    return { size: DEFAULT_SIZE, starsPerUnit: DEFAULT_STARS_PER_UNIT, regions };
+  }
+
+  it('should NOT mark (5,6) as a forced cross for the 5-cell P-pentomino region', () => {
+    const def = makePPentominoDef();
+    const state = createEmptyPuzzleState(def);
+
+    // Pre-mark (4,6) and (4,7) as crosses, matching the bug scenario.
+    state.cells[4][6] = 'cross';
+    state.cells[4][7] = 'cross';
+
+    // Collect all hints until no more are available, accumulating forced crosses.
+    // We want to ensure (5,6) is never suggested as a forced cross for region 7.
+    let hint = findSimpleShapesHint(state);
+    let iterations = 0;
+    while (hint !== null && iterations < 20) {
+      if (hint.kind === 'place-cross') {
+        expect(
+          hint.resultCells.some((rc) => rc.row === 5 && rc.col === 6),
+          `simple-shapes incorrectly forced (5,6) as a cross (hint: ${hint.explanation})`,
+        ).toBe(false);
+
+        // Apply the crosses so we can advance to the next hint.
+        for (const rc of hint.resultCells) {
+          state.cells[rc.row][rc.col] = 'cross';
+        }
+      } else if (hint.kind === 'place-star') {
+        for (const rc of hint.resultCells) {
+          state.cells[rc.row][rc.col] = 'star';
+        }
+      }
+
+      hint = findSimpleShapesHint(state);
+      iterations += 1;
+    }
+  });
+
+  it('valid star placement (3,6) and (5,8) is consistent with no forced cross at (5,6)', () => {
+    const def = makePPentominoDef();
+    const state = createEmptyPuzzleState(def);
+
+    // Pre-mark crosses.
+    state.cells[4][6] = 'cross';
+    state.cells[4][7] = 'cross';
+
+    // Place stars at the counterexample positions.
+    state.cells[3][6] = 'star';
+    state.cells[5][8] = 'star';
+
+    // (5,6) should remain empty — the hint system must not suggest it as a cross.
+    const hint = findSimpleShapesHint(state);
+    if (hint && hint.kind === 'place-cross') {
+      expect(
+        hint.resultCells.some((rc) => rc.row === 5 && rc.col === 6),
+        `simple-shapes incorrectly forced (5,6) as a cross after valid star placement`,
+      ).toBe(false);
+    }
+  });
+});
+
 


### PR DESCRIPTION
The findForcedCrossesForShape() helper assumed that whenever 3 region cells
occupy a 2x2 block, at least one must be a star (so the 4th non-region cell
is forced to be a cross). This pigeonhole argument only holds when the region
has ≤4 cells total — for larger regions both stars can sit in the cells
outside the block, making the deduction unsound.

Fix: before marking the 4th cell as a forced cross, verify that the remaining
stars cannot all be placed non-adjacently in the shape cells that lie outside
the 2x2 block. A new canPlaceNonAdjacentStars() helper performs this check
via simple backtracking (cell counts are tiny in practice).

Adds two regression tests covering the exact P-pentomino scenario from the
bug report (region G with cells (3,6),(4,6),(4,7),(5,7),(5,8) and pre-crossed
(4,6)/(4,7)): confirms (5,6) is no longer falsely forced as a cross.

https://claude.ai/code/session_01FSZbc6kHx6NKQ8mHhiA2Fu