### PR TITLE
feat: name the source of each constraint in combined hints

### DIFF
--- a/src/logic/techniques.ts
+++ b/src/logic/techniques.ts
@@ -377,7 +377,11 @@ export async function findNextHint(state: PuzzleState): Promise<Hint | null> {
       }
 
       if (result.type === 'hint') {
-        store.filteredDeductions = [];
+        // If the technique surfaced supporting deductions alongside the
+        // hint, expose them in the store so the UI's "Supporting deductions"
+        // panel can show which sub-facts the hint combines (useful for
+        // multi-fact hints like line saturation).
+        store.filteredDeductions = result.deductions ?? [];
         addLogEntry({
           timestamp: Date.now(),
           technique: tech.name,

--- a/src/logic/techniques/lineCaseSplit.ts
+++ b/src/logic/techniques/lineCaseSplit.ts
@@ -27,8 +27,14 @@ function nextHintId() {
  * the sum matches, every other empty cell in the line must be a cross —
  * surface that as a hint so the user sees the multi-fact reasoning rather
  * than a single-cell contradiction from one of the contributing techniques.
+ *
+ * Returns the hint plus the contributing AreaDeductions so the UI's
+ * Supporting deductions panel can show where each "≥k star" fact came from.
  */
-function trySaturationHint(deductions: Deduction[], state: PuzzleState): Hint | null {
+function trySaturationHint(
+  deductions: Deduction[],
+  state: PuzzleState,
+): { hint: Hint; supporting: Deduction[] } | null {
   const { size, starsPerUnit } = state.def;
   const areas = deductions.filter((d): d is AreaDeduction => d.kind === 'area');
 
@@ -86,29 +92,38 @@ function trySaturationHint(deductions: Deduction[], state: PuzzleState): Hint | 
         if (crosses.length === 0) continue;
 
         const lineLabel = lineType === 'row' ? formatRow(lineId) : formatCol(lineId);
-        const parts = selected.map((s) => {
+
+        // Per-subset bullets that name the source technique for each
+        // contributing ≥k fact, so the user can trace each constraint to its
+        // origin (region projection, case-split branch, etc.) without
+        // hunting around.
+        const subsetBullets = selected.map((s) => {
           const cellsStr = s.emptyCands.map((c) => `(${c.row},${c.col})`).join(', ');
-          return `≥${s.minStars} star${s.minStars === 1 ? '' : 's'} in {${cellsStr}}`;
+          const where = s.ded.explanation ?? `${s.ded.technique}`;
+          return `• ≥${s.minStars} star${s.minStars === 1 ? '' : 's'} in {${cellsStr}}  —  ${where}`;
         });
+
         const explanation =
           `${lineLabel} needs ${remaining} more star${remaining === 1 ? '' : 's'}. ` +
-          `Combined constraints require ${parts.join(' and ')}, ` +
-          `which together account for all of ${lineLabel.toLowerCase()}'s remaining stars. ` +
-          `The other empty cell${crosses.length === 1 ? '' : 's'} in ${lineLabel.toLowerCase()} must therefore be cross${crosses.length === 1 ? '' : 'es'}.`;
+          `Two disjoint subsets together account for all of them, so every other empty cell in ${lineLabel.toLowerCase()} must be a cross:\n` +
+          subsetBullets.join('\n');
 
         const highlightCells: Coords[] = [];
         for (const c of selected) highlightCells.push(...c.emptyCands);
         highlightCells.push(...crosses);
 
         return {
-          id: nextHintId(),
-          kind: 'place-cross',
-          technique: 'line-case-split',
-          resultCells: crosses,
-          explanation,
-          highlights: lineType === 'row'
-            ? { rows: [lineId], cells: highlightCells }
-            : { cols: [lineId], cells: highlightCells },
+          hint: {
+            id: nextHintId(),
+            kind: 'place-cross',
+            technique: 'line-case-split',
+            resultCells: crosses,
+            explanation,
+            highlights: lineType === 'row'
+              ? { rows: [lineId], cells: highlightCells }
+              : { cols: [lineId], cells: highlightCells },
+          },
+          supporting: selected.map((s) => s.ded),
         };
       }
     }
@@ -282,7 +297,7 @@ export function findLineCaseSplitResult(state: PuzzleState): TechniqueResult {
             areaId: otherId,
             candidateCells,
             minStars: 1,
-            explanation: `[split=${lineType}${lineId}] ${explanation}`,
+            explanation,
           };
           deductions.push(ded);
         }
@@ -309,9 +324,13 @@ export function findLineCaseSplitResult(state: PuzzleState): TechniqueResult {
   } else if (fpResult.type === 'hint' && fpResult.deductions) {
     combined.push(...fpResult.deductions);
   }
-  const saturationHint = trySaturationHint(combined, state);
-  if (saturationHint) {
-    return { type: 'hint', hint: saturationHint, deductions };
+  const saturation = trySaturationHint(combined, state);
+  if (saturation) {
+    // Return the saturation hint and surface the *contributing* AreaDeductions
+    // (each with its own explanation text identifying the source technique)
+    // as the result's deduction context, so the UI's Supporting deductions
+    // panel can show what the hint combined.
+    return { type: 'hint', hint: saturation.hint, deductions: saturation.supporting };
   }
 
   return { type: 'deductions', deductions };

--- a/tests/lineCaseSplitAndSaturation.test.ts
+++ b/tests/lineCaseSplitAndSaturation.test.ts
@@ -123,6 +123,15 @@ describe('Line saturation combines projections', () => {
     expect(lcs.hint.technique).toBe('line-case-split');
     const cellKeys = lcs.hint.resultCells.map((c) => `${c.row},${c.col}`);
     expect(cellKeys).toContain('3,4');
-    expect(lcs.hint.explanation).toMatch(/Combined constraints require/);
+    expect(lcs.hint.explanation).toMatch(/Two disjoint subsets/);
+    // The explanation should also name each contributing subset's source
+    // (region projection bullet + line-case-split bullet) so the user can
+    // trace each constraint back to where it came from.
+    expect(lcs.hint.explanation).toMatch(/region/i);
+    expect(lcs.hint.explanation).toMatch(/Splitting on/);
+    // And the contributing deductions should be returned alongside the hint
+    // so the UI's Supporting deductions panel can render them.
+    expect(lcs.deductions).toBeDefined();
+    expect((lcs.deductions ?? []).length).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Summary

When `line-case-split` returns a combined-constraint saturation hint, name the source of each `≥k stars in {…}` fact in both the main explanation and the Supporting deductions panel — so the user can trace the reasoning back to where it came from (which region projection, which case-split line) instead of seeing an opaque "Combined constraints require …".

### Before

> Column 5 needs 1 more star. Combined constraints require ≥1 star in {(2,5)}, which together account for all of column 5's remaining stars. The other empty cell in column 5 must therefore be cross.

### After

> Row 3 needs 2 more stars. Two disjoint subsets together account for all of them, so every other empty cell in row 3 must be a cross:
> • ≥1 star in {(3,9), (3,8)}  —  Splitting on Column 9's 2 possible placements, every case forces a star in Row 3 within {(3,9), (3,8)}.
> • ≥1 star in {(3,1), (3,3)}  —  Every valid placement of region A's stars puts at least 1 star(s) in Row 3, all within 2 candidate cell(s).

### What changed

- `trySaturationHint` in `lineCaseSplit.ts` now returns both the hint and the contributing `AreaDeduction`s, builds per-subset bullets that inline each source's existing explanation, and `findLineCaseSplitResult` passes those deductions back through `TechniqueResult.deductions`.
- `findNextHint` in `techniques.ts`: when a technique returns `type: 'hint'` with `deductions`, those deductions are now placed in `store.filteredDeductions` so the UI's "Supporting deductions" section renders them. Previously the field was unconditionally cleared on any hint result, hiding multi-fact context.
- The `[split=row3]`-style debug prefix on case-split projection explanations was redundant once they're inlined as a bullet (the human-readable "Splitting on Row 3's …" text already says where the split happened), so it's removed.

## Test plan

- [x] `tests/lineCaseSplitAndSaturation.test.ts` updated to assert the new explanation shape and that `result.deductions` carries the contributing sub-facts.
- [x] Full suite: `npx vitest run` — 339 passed | 4 skipped.

https://claude.ai/code/session_014eCmftSj6ofRUF9vJ4jKmn

---
_Generated by [Claude Code](https://claude.ai/code/session_014eCmftSj6ofRUF9vJ4jKmn)_