### PR TITLE
Add partial overcounting technique for band-budget saturation with partial confinement

### DIFF
--- a/src/logic/techniques.ts
+++ b/src/logic/techniques.ts
@@ -23,7 +23,7 @@ import { findForcedPlacementHint, findForcedPlacementResult } from './techniques
 import { findLineCaseSplitHint, findLineCaseSplitResult } from './techniques/lineCaseSplit';
 import { findSimpleShapesHint, findSimpleShapesResult } from './techniques/simpleShapes';
 import { findUndercountingHint, findUndercountingResult } from './techniques/undercounting';
-import { findOvercountingHint, findOvercountingResult } from './techniques/overcounting';
+import { findOvercountingHint, findOvercountingResult, findPartialOvercountingHint, findPartialOvercountingResult } from './techniques/overcounting';
 import { findFinnedCountsHint, findFinnedCountsResult } from './techniques/finnedCounts';
 import { findCompositeShapesHint, findCompositeShapesResult } from './techniques/compositeShapes';
 import { findSqueezeHint, findSqueezeResult } from './techniques/squeeze';
@@ -177,6 +177,13 @@ export const techniquesInOrder: Technique[] = [
     expensive: true,
     findHint: findOvercountingHint,
     findResult: findOvercountingResult,
+  },
+  {
+    id: 'partial-overcounting',
+    name: 'Partial Overcounting',
+    expensive: true,
+    findHint: findPartialOvercountingHint,
+    findResult: findPartialOvercountingResult,
   },
   {
     id: 'square-counting',

--- a/src/logic/techniques/overcounting.ts
+++ b/src/logic/techniques/overcounting.ts
@@ -371,3 +371,237 @@ export function findOvercountingResult(state: PuzzleState): TechniqueResult {
   if (hint) return { type: 'hint', hint };
   return { type: 'none' };
 }
+
+/**
+ * Maximum stars that can be simultaneously placed from a candidate cell set.
+ *
+ * Tries all k-subsets (largest k first) until one passes canPlaceAllStarsSimultaneously.
+ * Returns a conservative fallback (= limit) for very large sets to keep runtime bounded.
+ */
+function maxPackableStars(
+  cells: Coords[],
+  limit: number,
+  state: PuzzleState,
+  starsPerUnit: number,
+): number {
+  const maxK = Math.min(limit, cells.length);
+  if (maxK === 0) return 0;
+  // Conservative fallback for large sets: returning `limit` may overestimate, which is the
+  // safe direction (gives minInBand = 0, so we miss deductions rather than generate wrong ones).
+  if (cells.length > 8) return limit;
+  for (let k = maxK; k >= 1; k -= 1) {
+    for (const subset of combinations(cells, k)) {
+      if (canPlaceAllStarsSimultaneously(state, subset, starsPerUnit) !== null) {
+        return k;
+      }
+    }
+  }
+  return 0;
+}
+
+/**
+ * PARTIAL OVERCOUNTING
+ *
+ * Generalisation of overcounting that handles regions which are only *partially*
+ * confined to a band (set of rows or columns).
+ *
+ * For every region R define:
+ *   minInBand(R) = max(0, R.remaining − maxPackableOutside(R, band))
+ *
+ * where maxPackableOutside is the largest k such that k outside-band candidate cells
+ * of R can simultaneously be stars (checked via canPlaceAllStarsSimultaneously).
+ *
+ * If Σ minInBand == cap(band), the band is exactly filled by mandatory contributions,
+ * so any region with minInBand == 0 cannot place a star in the band.
+ *
+ * Soundness: canPlaceAllStarsSimultaneously only approves locally valid placements, so
+ * computed maxPackableOutside ≥ actual maxPackableOutside, meaning computed minInBand ≤
+ * actual minInBand.  If computed Σ minInBand = cap, actual Σ minInBand = cap too (since
+ * actual Σ ≤ cap always), and each per-region value matches — making the conclusion safe.
+ */
+export function findPartialOvercountingHint(state: PuzzleState): Hint | null {
+  const { size, starsPerUnit } = state.def;
+
+  const regionIdSet = new Set<number>();
+  for (let r = 0; r < size; r += 1) {
+    for (let c = 0; c < size; c += 1) {
+      regionIdSet.add(state.def.regions[r][c]);
+    }
+  }
+  const regionIds = Array.from(regionIdSet).sort((a, b) => a - b);
+
+  const starCandidateCache = new Map<string, boolean>();
+  function isStarCandidate(cell: Coords): boolean {
+    const k = cellKey(cell);
+    const cached = starCandidateCache.get(k);
+    if (cached !== undefined) return cached;
+    const ok =
+      emptyCells(state, [cell]).length === 1 &&
+      canPlaceAllStarsSimultaneously(state, [cell], starsPerUnit) !== null;
+    starCandidateCache.set(k, ok);
+    return ok;
+  }
+
+  const rowInfos: UnitInfo[] = Array.from({ length: size }, (_, r) => {
+    const cells = rowCells(state, r);
+    const stars = countStars(state, cells);
+    return { cells, remaining: starsPerUnit - stars };
+  });
+
+  const colInfos: UnitInfo[] = Array.from({ length: size }, (_, c) => {
+    const cells = colCells(state, c);
+    const stars = countStars(state, cells);
+    return { cells, remaining: starsPerUnit - stars };
+  });
+
+  const regionInfoMap = new Map<number, RegionInfo>();
+  for (const id of regionIds) {
+    const cells = regionCells(state, id);
+    const stars = countStars(state, cells);
+    const remaining = starsPerUnit - stars;
+    const empties = emptyCells(state, cells);
+    const candidateEmpties = empties.filter(isStarCandidate);
+    regionInfoMap.set(id, { id, cells, remaining, candidateEmpties });
+  }
+
+  let bestHint: { hint: Hint; score: number } | null = null;
+
+  function tryBand(
+    bandIndices: number[],
+    cap: number,
+    bandSet: Set<number>,
+    isRow: boolean,
+  ) {
+    if (cap <= 0) return;
+
+    // Compute minInBand for every region and sum them
+    let totalMin = 0;
+    const minInBandMap = new Map<number, number>();
+
+    for (const id of regionIds) {
+      const reg = regionInfoMap.get(id)!;
+      if (reg.remaining <= 0) {
+        minInBandMap.set(id, 0);
+        continue;
+      }
+      const outsideCandidates = reg.candidateEmpties.filter(
+        (c) => !(isRow ? bandSet.has(c.row) : bandSet.has(c.col)),
+      );
+      const maxOut = maxPackableStars(outsideCandidates, reg.remaining, state, starsPerUnit);
+      const minIn = Math.max(0, reg.remaining - maxOut);
+      minInBandMap.set(id, minIn);
+      totalMin += minIn;
+      if (totalMin > cap) return; // early exit
+    }
+
+    if (totalMin !== cap) return;
+
+    // Regions with minInBand == 0 cannot place stars in the band
+    const forcedCrosses: Coords[] = [];
+    const zeroRegions: number[] = [];
+    const positiveRegions: number[] = [];
+
+    for (const id of regionIds) {
+      const minIn = minInBandMap.get(id) ?? 0;
+      const reg = regionInfoMap.get(id)!;
+      if (minIn === 0 && reg.remaining > 0) zeroRegions.push(id);
+      if (minIn > 0) positiveRegions.push(id);
+    }
+
+    for (const idx of bandIndices) {
+      const unitCells = isRow ? rowInfos[idx].cells : colInfos[idx].cells;
+      for (const cell of unitCells) {
+        const cellRegion = state.def.regions[cell.row][cell.col];
+        if ((minInBandMap.get(cellRegion) ?? 0) === 0) {
+          if (emptyCells(state, [cell]).length === 1) {
+            forcedCrosses.push(cell);
+          }
+        }
+      }
+    }
+
+    if (forcedCrosses.length === 0) return;
+
+    const bandLabel = isRow
+      ? formatUnitList(bandIndices, formatRow)
+      : formatUnitList(bandIndices, formatCol);
+
+    // Build per-region capacity notes for the explanation
+    const partialNotes = positiveRegions
+      .filter((id) => {
+        const reg = regionInfoMap.get(id)!;
+        const minIn = minInBandMap.get(id) ?? 0;
+        return minIn > 0 && minIn < reg.remaining;
+      })
+      .map((id) => {
+        const reg = regionInfoMap.get(id)!;
+        const minIn = minInBandMap.get(id) ?? 0;
+        const maxOut = reg.remaining - minIn;
+        return (
+          `${formatRegions([id])} needs ${reg.remaining} star(s) but can place at most ${maxOut} ` +
+          `outside ${bandLabel} (outside cells cannot all be stars simultaneously), ` +
+          `so at least ${minIn} must be inside`
+        );
+      });
+
+    const fullyConfinedNotes = positiveRegions
+      .filter((id) => {
+        const reg = regionInfoMap.get(id)!;
+        return (minInBandMap.get(id) ?? 0) === reg.remaining;
+      })
+      .map((id) => {
+        const reg = regionInfoMap.get(id)!;
+        return `${formatRegions([id])} is fully confined to ${bandLabel} (${reg.remaining} star(s))`;
+      });
+
+    const allNotes = [...fullyConfinedNotes, ...partialNotes].join('; ');
+
+    const explanation =
+      `${bandLabel} need${bandIndices.length > 1 ? '' : 's'} ${cap} star(s) in total. ` +
+      (allNotes ? `${allNotes}. ` : '') +
+      `The mandatory contributions already sum to ${cap}, so no room remains for other regions. ` +
+      `${formatRegions(zeroRegions.slice(0, 5))} can place all their stars outside this band and must do so — ` +
+      `their cells here are crosses.`;
+
+    const hint: Hint = {
+      id: nextHintId(),
+      kind: 'place-cross',
+      technique: 'partial-overcounting',
+      resultCells: uniqueCells(forcedCrosses),
+      explanation,
+      highlights: {
+        ...(isRow ? { rows: bandIndices } : { cols: bandIndices }),
+        regions: positiveRegions,
+        cells: uniqueCells(forcedCrosses),
+      },
+    };
+
+    const score = forcedCrosses.length * 1000 - bandIndices.length;
+    if (!bestHint || score > bestHint.score) {
+      bestHint = { hint, score };
+    }
+  }
+
+  const maxBandSize = Math.min(4, size);
+  const rowIndices = Array.from({ length: size }, (_, i) => i);
+  const colIndices = Array.from({ length: size }, (_, i) => i);
+
+  for (let bandSize = 1; bandSize <= maxBandSize; bandSize += 1) {
+    for (const rows of combinations(rowIndices, bandSize)) {
+      const cap = rows.reduce((s, r) => s + Math.max(0, rowInfos[r].remaining), 0);
+      tryBand(rows, cap, new Set(rows), true);
+    }
+    for (const cols of combinations(colIndices, bandSize)) {
+      const cap = cols.reduce((s, c) => s + Math.max(0, colInfos[c].remaining), 0);
+      tryBand(cols, cap, new Set(cols), false);
+    }
+  }
+
+  return (bestHint as { hint: Hint; score: number } | null)?.hint ?? null;
+}
+
+export function findPartialOvercountingResult(state: PuzzleState): TechniqueResult {
+  const hint = findPartialOvercountingHint(state);
+  if (hint) return { type: 'hint', hint };
+  return { type: 'none' };
+}

--- a/src/types/hints.ts
+++ b/src/types/hints.ts
@@ -22,6 +22,7 @@ export type TechniqueId =
   // 2. Counting
   | 'undercounting'
   | 'overcounting'
+  | 'partial-overcounting'
   | 'finned-counts'
   | 'composite-shapes'
   | 'squeeze'

--- a/tests/partialOvercounting.test.ts
+++ b/tests/partialOvercounting.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { findPartialOvercountingHint } from '../src/logic/techniques/overcounting';
+import type { PuzzleState, PuzzleDef, CellState } from '../src/types/puzzle';
+
+function makeState(
+  size: number,
+  starsPerUnit: number,
+  regions: number[][],
+  cells: CellState[][],
+): PuzzleState {
+  const def: PuzzleDef = { size, starsPerUnit, regions };
+  return { def, cells };
+}
+
+function emptyGrid(size: number): CellState[][] {
+  return Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => 'empty' as CellState),
+  );
+}
+
+describe('Partial Overcounting', () => {
+  /**
+   * Replicates the exact user scenario:
+   *
+   * Regions 0-1 are fully confined to rows 0-2 (2 stars each).
+   * Regions 2-3 each have exactly one 2x2-adjacent pair outside rows 0-2
+   * so they can only pack 1 star outside → must place at least 1 star in rows 0-2.
+   * Total min-in-band = 2+2+1+1 = 6 = cap(rows 0-2).
+   * → Regions 4 and 5 cells in rows 0-2 must be crosses.
+   */
+  it('detects partial confinement when outside cells are mutually adjacent', () => {
+    // 10x10, 2 stars per unit
+    const size = 10;
+    const starsPerUnit = 2;
+
+    // Simplified region layout matching the structure described:
+    //   region 0: rows 0-1, cols 0-3         (fully confined to rows 0-2)
+    //   region 1: rows 0-2, cols 4-9 + (2,9) (fully confined to rows 0-2)
+    //   region 2: rows 1-4, cols 0-3         (outside pair: (3,0)+(4,0) — adjacent)
+    //   region 3: rows 1-4, cols 4-7         (outside pair: (3,4)+(4,4) — adjacent)
+    //   region 4: rows 1-2, cols 7-8         (outside: rows 3+, plenty of room)
+    //   region 5: rows 2, col 0              (can easily go outside)
+    //   region 6+: fill the rest
+    const R = Array.from({ length: size }, () => Array(size).fill(9) as number[]);
+
+    // Region 0: rows 0-1, cols 0-3
+    for (let r = 0; r <= 1; r++) for (let c = 0; c <= 3; c++) R[r][c] = 0;
+    // Region 1: rows 0-2, cols 4-9
+    for (let r = 0; r <= 2; r++) for (let c = 4; c <= 9; c++) R[r][c] = 1;
+    // Region 2: rows 1-4, cols 0-3  (outside = rows 3-4, cols 0-3 → pairs are adjacent)
+    for (let r = 1; r <= 4; r++) for (let c = 0; c <= 3; c++) R[r][c] = 2;
+    // Region 3: rows 1-4, cols 4-7  (outside = rows 3-4, cols 4-7 → pairs adjacent)
+    for (let r = 1; r <= 4; r++) for (let c = 4; c <= 7; c++) R[r][c] = 3;
+    // Region 4: rows 1-4, cols 8-9  (outside = rows 3-4, cols 8-9 → plenty of room)
+    for (let r = 1; r <= 4; r++) for (let c = 8; c <= 9; c++) R[r][c] = 4;
+    // Region 5: rows 5-9, cols 0-4
+    for (let r = 5; r <= 9; r++) for (let c = 0; c <= 4; c++) R[r][c] = 5;
+    // Region 6: rows 5-9, cols 5-9
+    for (let r = 5; r <= 9; r++) for (let c = 5; c <= 9; c++) R[r][c] = 6;
+
+    const cells = emptyGrid(size);
+
+    const state = makeState(size, starsPerUnit, R, cells);
+    const hint = findPartialOvercountingHint(state);
+
+    // The technique should fire and produce crosses somewhere in rows 0-2
+    // (specifically cells belonging to region 4 or 5 that are in rows 0-2)
+    expect(hint).not.toBeNull();
+    if (!hint) return;
+
+    expect(hint.kind).toBe('place-cross');
+    expect(hint.technique).toBe('partial-overcounting');
+    expect(hint.resultCells.length).toBeGreaterThan(0);
+
+    // All forced crosses must be empty cells in rows 0-2
+    for (const cell of hint.resultCells) {
+      expect(cell.row).toBeLessThanOrEqual(2);
+    }
+  });
+
+  /**
+   * Classic full-confinement case: region 1 spans all 6 rows but can escape the
+   * lower band (rows 3-5) via its upper-band cells. Regions 4-6 are fully confined
+   * to rows 3-5, saturating that band's budget so region 1 is forced out.
+   *
+   * Layout (starsPerUnit=1):
+   *   row 0-2: [1,1, 2,2, 3,3]
+   *   row 3-5: [1,4, 5,5, 6,6]
+   * Region 1 spans all rows (col 0 rows 0-5, col 1 rows 0-2 only).
+   */
+  it('handles the classic full-confinement case', () => {
+    const size = 6;
+    const starsPerUnit = 1;
+
+    const R: number[][] = [
+      [1, 1, 2, 2, 3, 3],
+      [1, 1, 2, 2, 3, 3],
+      [1, 1, 2, 2, 3, 3],
+      [1, 4, 5, 5, 6, 6],
+      [1, 4, 5, 5, 6, 6],
+      [1, 4, 5, 5, 6, 6],
+    ];
+
+    const cells = emptyGrid(size);
+    const state = makeState(size, starsPerUnit, R, cells);
+    const hint = findPartialOvercountingHint(state);
+
+    // Should find forced crosses (region 1 cells in rows 3-5 must be crosses
+    // because regions 4-6 already saturate the band budget)
+    expect(hint).not.toBeNull();
+    expect(hint?.kind).toBe('place-cross');
+    expect(hint?.technique).toBe('partial-overcounting');
+    expect(hint?.resultCells.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * No hint when adjacent outside cells give each partially-confined region
+   * enough room to escape the band with no budget overflow.
+   */
+  it('returns null when band budget is not saturated', () => {
+    const size = 6;
+    const starsPerUnit = 1;
+
+    // All regions span all 6 rows → minInBand = 0 for every region → totalMin = 0 ≠ cap
+    const R: number[][] = [
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+    ];
+
+    const cells = emptyGrid(size);
+    const state = makeState(size, starsPerUnit, R, cells);
+    const hint = findPartialOvercountingHint(state);
+
+    expect(hint).toBeNull();
+  });
+});


### PR DESCRIPTION
Extends overcounting to handle regions that are only partially confined to a band.
For each region, computes minInBand = max(0, remaining - maxPackableOutside), where
maxPackableOutside is found via canPlaceAllStarsSimultaneously on all k-subsets of
outside candidates. If Σ minInBand equals the band's star budget, all remaining
capacity is consumed by mandatory contributions, so any region with minInBand=0
cannot place stars in the band.

This catches the scenario where regions have a limited outside footprint (e.g. only
one 2×2 block of adjacent cells) that can hold at most 1 star, forcing the region
to contribute at least 1 star to the band.

https://claude.ai/code/session_01Euer7su2CiAfDTZGXK1nX1