### PR TITLE
Partial constraints: overcounting, locked footprint, and tighter undercounting

### DIFF
--- a/src/logic/techniques.ts
+++ b/src/logic/techniques.ts
@@ -23,7 +23,7 @@ import { findForcedPlacementHint, findForcedPlacementResult } from './techniques
 import { findLineCaseSplitHint, findLineCaseSplitResult } from './techniques/lineCaseSplit';
 import { findSimpleShapesHint, findSimpleShapesResult } from './techniques/simpleShapes';
 import { findUndercountingHint, findUndercountingResult } from './techniques/undercounting';
-import { findOvercountingHint, findOvercountingResult, findPartialOvercountingHint, findPartialOvercountingResult } from './techniques/overcounting';
+import { findOvercountingHint, findOvercountingResult, findPartialOvercountingHint, findPartialOvercountingResult, findLockedOutsideFootprintHint, findLockedOutsideFootprintResult } from './techniques/overcounting';
 import { findFinnedCountsHint, findFinnedCountsResult } from './techniques/finnedCounts';
 import { findCompositeShapesHint, findCompositeShapesResult } from './techniques/compositeShapes';
 import { findSqueezeHint, findSqueezeResult } from './techniques/squeeze';
@@ -184,6 +184,13 @@ export const techniquesInOrder: Technique[] = [
     expensive: true,
     findHint: findPartialOvercountingHint,
     findResult: findPartialOvercountingResult,
+  },
+  {
+    id: 'locked-outside-footprint',
+    name: 'Locked Outside Footprint',
+    expensive: true,
+    findHint: findLockedOutsideFootprintHint,
+    findResult: findLockedOutsideFootprintResult,
   },
   {
     id: 'square-counting',

--- a/src/logic/techniques.ts
+++ b/src/logic/techniques.ts
@@ -23,7 +23,7 @@ import { findForcedPlacementHint, findForcedPlacementResult } from './techniques
 import { findLineCaseSplitHint, findLineCaseSplitResult } from './techniques/lineCaseSplit';
 import { findSimpleShapesHint, findSimpleShapesResult } from './techniques/simpleShapes';
 import { findUndercountingHint, findUndercountingResult } from './techniques/undercounting';
-import { findOvercountingHint, findOvercountingResult } from './techniques/overcounting';
+import { findOvercountingHint, findOvercountingResult, findPartialOvercountingHint, findPartialOvercountingResult } from './techniques/overcounting';
 import { findFinnedCountsHint, findFinnedCountsResult } from './techniques/finnedCounts';
 import { findCompositeShapesHint, findCompositeShapesResult } from './techniques/compositeShapes';
 import { findSqueezeHint, findSqueezeResult } from './techniques/squeeze';
@@ -177,6 +177,13 @@ export const techniquesInOrder: Technique[] = [
     expensive: true,
     findHint: findOvercountingHint,
     findResult: findOvercountingResult,
+  },
+  {
+    id: 'partial-overcounting',
+    name: 'Partial Overcounting',
+    expensive: true,
+    findHint: findPartialOvercountingHint,
+    findResult: findPartialOvercountingResult,
   },
   {
     id: 'square-counting',

--- a/src/logic/techniques/overcounting.ts
+++ b/src/logic/techniques/overcounting.ts
@@ -371,3 +371,237 @@ export function findOvercountingResult(state: PuzzleState): TechniqueResult {
   if (hint) return { type: 'hint', hint };
   return { type: 'none' };
 }
+
+/**
+ * Maximum stars that can be simultaneously placed from a candidate cell set.
+ *
+ * Tries all k-subsets (largest k first) until one passes canPlaceAllStarsSimultaneously.
+ * Returns a conservative fallback (= limit) for very large sets to keep runtime bounded.
+ */
+function maxPackableStars(
+  cells: Coords[],
+  limit: number,
+  state: PuzzleState,
+  starsPerUnit: number,
+): number {
+  const maxK = Math.min(limit, cells.length);
+  if (maxK === 0) return 0;
+  // Conservative fallback for large sets: returning `limit` may overestimate, which is the
+  // safe direction (gives minInBand = 0, so we miss deductions rather than generate wrong ones).
+  if (cells.length > 8) return limit;
+  for (let k = maxK; k >= 1; k -= 1) {
+    for (const subset of combinations(cells, k)) {
+      if (canPlaceAllStarsSimultaneously(state, subset, starsPerUnit) !== null) {
+        return k;
+      }
+    }
+  }
+  return 0;
+}
+
+/**
+ * PARTIAL OVERCOUNTING
+ *
+ * Generalisation of overcounting that handles regions which are only *partially*
+ * confined to a band (set of rows or columns).
+ *
+ * For every region R define:
+ *   minInBand(R) = max(0, R.remaining − maxPackableOutside(R, band))
+ *
+ * where maxPackableOutside is the largest k such that k outside-band candidate cells
+ * of R can simultaneously be stars (checked via canPlaceAllStarsSimultaneously).
+ *
+ * If Σ minInBand == cap(band), the band is exactly filled by mandatory contributions,
+ * so any region with minInBand == 0 cannot place a star in the band.
+ *
+ * Soundness: canPlaceAllStarsSimultaneously only approves locally valid placements, so
+ * computed maxPackableOutside ≥ actual maxPackableOutside, meaning computed minInBand ≤
+ * actual minInBand.  If computed Σ minInBand = cap, actual Σ minInBand = cap too (since
+ * actual Σ ≤ cap always), and each per-region value matches — making the conclusion safe.
+ */
+export function findPartialOvercountingHint(state: PuzzleState): Hint | null {
+  const { size, starsPerUnit } = state.def;
+
+  const regionIdSet = new Set<number>();
+  for (let r = 0; r < size; r += 1) {
+    for (let c = 0; c < size; c += 1) {
+      regionIdSet.add(state.def.regions[r][c]);
+    }
+  }
+  const regionIds = Array.from(regionIdSet).sort((a, b) => a - b);
+
+  const starCandidateCache = new Map<string, boolean>();
+  function isStarCandidate(cell: Coords): boolean {
+    const k = cellKey(cell);
+    const cached = starCandidateCache.get(k);
+    if (cached !== undefined) return cached;
+    const ok =
+      emptyCells(state, [cell]).length === 1 &&
+      canPlaceAllStarsSimultaneously(state, [cell], starsPerUnit) !== null;
+    starCandidateCache.set(k, ok);
+    return ok;
+  }
+
+  const rowInfos: UnitInfo[] = Array.from({ length: size }, (_, r) => {
+    const cells = rowCells(state, r);
+    const stars = countStars(state, cells);
+    return { cells, remaining: starsPerUnit - stars };
+  });
+
+  const colInfos: UnitInfo[] = Array.from({ length: size }, (_, c) => {
+    const cells = colCells(state, c);
+    const stars = countStars(state, cells);
+    return { cells, remaining: starsPerUnit - stars };
+  });
+
+  const regionInfoMap = new Map<number, RegionInfo>();
+  for (const id of regionIds) {
+    const cells = regionCells(state, id);
+    const stars = countStars(state, cells);
+    const remaining = starsPerUnit - stars;
+    const empties = emptyCells(state, cells);
+    const candidateEmpties = empties.filter(isStarCandidate);
+    regionInfoMap.set(id, { id, cells, remaining, candidateEmpties });
+  }
+
+  let bestHint: { hint: Hint; score: number } | null = null;
+
+  function tryBand(
+    bandIndices: number[],
+    cap: number,
+    bandSet: Set<number>,
+    isRow: boolean,
+  ) {
+    if (cap <= 0) return;
+
+    // Compute minInBand for every region and sum them
+    let totalMin = 0;
+    const minInBandMap = new Map<number, number>();
+
+    for (const id of regionIds) {
+      const reg = regionInfoMap.get(id)!;
+      if (reg.remaining <= 0) {
+        minInBandMap.set(id, 0);
+        continue;
+      }
+      const outsideCandidates = reg.candidateEmpties.filter(
+        (c) => !(isRow ? bandSet.has(c.row) : bandSet.has(c.col)),
+      );
+      const maxOut = maxPackableStars(outsideCandidates, reg.remaining, state, starsPerUnit);
+      const minIn = Math.max(0, reg.remaining - maxOut);
+      minInBandMap.set(id, minIn);
+      totalMin += minIn;
+      if (totalMin > cap) return; // early exit
+    }
+
+    if (totalMin !== cap) return;
+
+    // Regions with minInBand == 0 cannot place stars in the band
+    const forcedCrosses: Coords[] = [];
+    const zeroRegions: number[] = [];
+    const positiveRegions: number[] = [];
+
+    for (const id of regionIds) {
+      const minIn = minInBandMap.get(id) ?? 0;
+      const reg = regionInfoMap.get(id)!;
+      if (minIn === 0 && reg.remaining > 0) zeroRegions.push(id);
+      if (minIn > 0) positiveRegions.push(id);
+    }
+
+    for (const idx of bandIndices) {
+      const unitCells = isRow ? rowInfos[idx].cells : colInfos[idx].cells;
+      for (const cell of unitCells) {
+        const cellRegion = state.def.regions[cell.row][cell.col];
+        if ((minInBandMap.get(cellRegion) ?? 0) === 0) {
+          if (emptyCells(state, [cell]).length === 1) {
+            forcedCrosses.push(cell);
+          }
+        }
+      }
+    }
+
+    if (forcedCrosses.length === 0) return;
+
+    const bandLabel = isRow
+      ? formatUnitList(bandIndices, formatRow)
+      : formatUnitList(bandIndices, formatCol);
+
+    // Build per-region capacity notes for the explanation
+    const partialNotes = positiveRegions
+      .filter((id) => {
+        const reg = regionInfoMap.get(id)!;
+        const minIn = minInBandMap.get(id) ?? 0;
+        return minIn > 0 && minIn < reg.remaining;
+      })
+      .map((id) => {
+        const reg = regionInfoMap.get(id)!;
+        const minIn = minInBandMap.get(id) ?? 0;
+        const maxOut = reg.remaining - minIn;
+        return (
+          `${formatRegions([id])} needs ${reg.remaining} star(s) but can place at most ${maxOut} ` +
+          `outside ${bandLabel} (outside cells cannot all be stars simultaneously), ` +
+          `so at least ${minIn} must be inside`
+        );
+      });
+
+    const fullyConfinedNotes = positiveRegions
+      .filter((id) => {
+        const reg = regionInfoMap.get(id)!;
+        return (minInBandMap.get(id) ?? 0) === reg.remaining;
+      })
+      .map((id) => {
+        const reg = regionInfoMap.get(id)!;
+        return `${formatRegions([id])} is fully confined to ${bandLabel} (${reg.remaining} star(s))`;
+      });
+
+    const allNotes = [...fullyConfinedNotes, ...partialNotes].join('; ');
+
+    const explanation =
+      `${bandLabel} need${bandIndices.length > 1 ? '' : 's'} ${cap} star(s) in total. ` +
+      (allNotes ? `${allNotes}. ` : '') +
+      `The mandatory contributions already sum to ${cap}, so no room remains for other regions. ` +
+      `${formatRegions(zeroRegions.slice(0, 5))} can place all their stars outside this band and must do so — ` +
+      `their cells here are crosses.`;
+
+    const hint: Hint = {
+      id: nextHintId(),
+      kind: 'place-cross',
+      technique: 'partial-overcounting',
+      resultCells: uniqueCells(forcedCrosses),
+      explanation,
+      highlights: {
+        ...(isRow ? { rows: bandIndices } : { cols: bandIndices }),
+        regions: positiveRegions,
+        cells: uniqueCells(forcedCrosses),
+      },
+    };
+
+    const score = forcedCrosses.length * 1000 - bandIndices.length;
+    if (!bestHint || score > bestHint.score) {
+      bestHint = { hint, score };
+    }
+  }
+
+  const maxBandSize = Math.min(4, size);
+  const rowIndices = Array.from({ length: size }, (_, i) => i);
+  const colIndices = Array.from({ length: size }, (_, i) => i);
+
+  for (let bandSize = 1; bandSize <= maxBandSize; bandSize += 1) {
+    for (const rows of combinations(rowIndices, bandSize)) {
+      const cap = rows.reduce((s, r) => s + Math.max(0, rowInfos[r].remaining), 0);
+      tryBand(rows, cap, new Set(rows), true);
+    }
+    for (const cols of combinations(colIndices, bandSize)) {
+      const cap = cols.reduce((s, c) => s + Math.max(0, colInfos[c].remaining), 0);
+      tryBand(cols, cap, new Set(cols), false);
+    }
+  }
+
+  return (bestHint as { hint: Hint; score: number } | null)?.hint ?? null;
+}
+
+export function findPartialOvercountingResult(state: PuzzleState): TechniqueResult {
+  const hint = findPartialOvercountingHint(state);
+  if (hint) return { type: 'hint', hint };
+  return { type: 'none' };
+}

--- a/src/logic/techniques/overcounting.ts
+++ b/src/logic/techniques/overcounting.ts
@@ -7,6 +7,7 @@ import {
   regionCells,
   countStars,
   emptyCells,
+  neighbors8,
   formatRow,
   formatCol,
   formatRegions,
@@ -602,6 +603,191 @@ export function findPartialOvercountingHint(state: PuzzleState): Hint | null {
 
 export function findPartialOvercountingResult(state: PuzzleState): TechniqueResult {
   const hint = findPartialOvercountingHint(state);
+  if (hint) return { type: 'hint', hint };
+  return { type: 'none' };
+}
+
+/**
+ * LOCKED OUTSIDE FOOTPRINT
+ *
+ * The symmetric companion to partial overcounting. Once a band B is saturated
+ * (Σ minInBand = cap), each region contributes exactly minInBand stars inside
+ * and exactly (remaining − minInBand) = k stars outside. Those k outside stars
+ * must land in the region's outside candidates S.
+ *
+ * A cell C outside S is a forced cross when |S \ N₈(C)| < k:
+ *   fewer than k members of S are non-adjacent to C, so no matter which k cells
+ *   of S hold the stars, at least one is adjacent to C.
+ *
+ * For k = 1 this reduces to: C is adjacent to every member of S.
+ * For k = 2 with |S| = 2: C is adjacent to at least one member (standard pair exclusion).
+ */
+export function findLockedOutsideFootprintHint(state: PuzzleState): Hint | null {
+  const { size, starsPerUnit } = state.def;
+
+  const regionIdSet = new Set<number>();
+  for (let r = 0; r < size; r += 1) {
+    for (let c = 0; c < size; c += 1) {
+      regionIdSet.add(state.def.regions[r][c]);
+    }
+  }
+  const regionIds = Array.from(regionIdSet).sort((a, b) => a - b);
+
+  const starCandidateCache = new Map<string, boolean>();
+  function isStarCandidate(cell: Coords): boolean {
+    const k = cellKey(cell);
+    const cached = starCandidateCache.get(k);
+    if (cached !== undefined) return cached;
+    const ok =
+      emptyCells(state, [cell]).length === 1 &&
+      canPlaceAllStarsSimultaneously(state, [cell], starsPerUnit) !== null;
+    starCandidateCache.set(k, ok);
+    return ok;
+  }
+
+  const rowInfos: UnitInfo[] = Array.from({ length: size }, (_, r) => {
+    const cells = rowCells(state, r);
+    return { cells, remaining: starsPerUnit - countStars(state, cells) };
+  });
+  const colInfos: UnitInfo[] = Array.from({ length: size }, (_, c) => {
+    const cells = colCells(state, c);
+    return { cells, remaining: starsPerUnit - countStars(state, cells) };
+  });
+
+  const regionInfoMap = new Map<number, RegionInfo>();
+  for (const id of regionIds) {
+    const cells = regionCells(state, id);
+    const remaining = starsPerUnit - countStars(state, cells);
+    const candidateEmpties = emptyCells(state, cells).filter(isStarCandidate);
+    regionInfoMap.set(id, { id, cells, remaining, candidateEmpties });
+  }
+
+  let bestHint: { hint: Hint; score: number } | null = null;
+
+  function tryBand(bandIndices: number[], cap: number, bandSet: Set<number>, isRow: boolean) {
+    if (cap <= 0) return;
+
+    // Check band saturation: Σ minInBand must equal cap
+    let totalMin = 0;
+    const minInBandMap = new Map<number, number>();
+    const outsideCandMap = new Map<number, Coords[]>();
+
+    for (const id of regionIds) {
+      const reg = regionInfoMap.get(id)!;
+      if (reg.remaining <= 0) { minInBandMap.set(id, 0); outsideCandMap.set(id, []); continue; }
+      const outside = reg.candidateEmpties.filter(
+        (c) => !(isRow ? bandSet.has(c.row) : bandSet.has(c.col)),
+      );
+      const maxOut = maxPackableStars(outside, reg.remaining, state, starsPerUnit);
+      const minIn = Math.max(0, reg.remaining - maxOut);
+      minInBandMap.set(id, minIn);
+      outsideCandMap.set(id, outside);
+      totalMin += minIn;
+      if (totalMin > cap) return;
+    }
+    if (totalMin !== cap) return;
+
+    // For each region with k_outside > 0, apply the locked-footprint adjacency argument
+    const forcedCrosses: Coords[] = [];
+    const lockedRegions: number[] = [];
+
+    for (const id of regionIds) {
+      const reg = regionInfoMap.get(id)!;
+      if (reg.remaining <= 0) continue;
+      const minIn = minInBandMap.get(id) ?? 0;
+      const kOutside = reg.remaining - minIn;
+      if (kOutside <= 0) continue;
+
+      const S = outsideCandMap.get(id) ?? [];
+      if (S.length === 0 || S.length < kOutside) continue;
+
+      const sKeys = new Set(S.map(cellKey));
+
+      // For each empty cell not in S, check if |S \ N₈(cell)| < kOutside
+      for (let r = 0; r < size; r += 1) {
+        for (let c = 0; c < size; c += 1) {
+          const cell = { row: r, col: c };
+          if (sKeys.has(cellKey(cell))) continue;
+          if (emptyCells(state, [cell]).length === 0) continue;
+
+          // Count members of S that are NOT 8-adjacent to this cell
+          let nonAdj = 0;
+          for (const s of S) {
+            if (Math.abs(r - s.row) > 1 || Math.abs(c - s.col) > 1) {
+              nonAdj += 1;
+              if (nonAdj >= kOutside) break; // early exit: can't be forced cross
+            }
+          }
+          if (nonAdj < kOutside) {
+            forcedCrosses.push(cell);
+          }
+        }
+      }
+
+      if (S.length > 0 && forcedCrosses.length > 0) lockedRegions.push(id);
+    }
+
+    if (forcedCrosses.length === 0) return;
+
+    const bandLabel = isRow
+      ? formatUnitList(bandIndices, formatRow)
+      : formatUnitList(bandIndices, formatCol);
+
+    const regionNotes = lockedRegions.map((id) => {
+      const reg = regionInfoMap.get(id)!;
+      const minIn = minInBandMap.get(id) ?? 0;
+      const kOut = reg.remaining - minIn;
+      const S = outsideCandMap.get(id) ?? [];
+      return (
+        `${formatRegions([id])} must place exactly ${kOut} star(s) among its ` +
+        `${S.length} outside candidate(s) — cells adjacent to all of them are blocked`
+      );
+    });
+
+    const explanation =
+      `${bandLabel} is saturated (mandatory contributions fill its budget). ` +
+      `${regionNotes.join('; ')}. ` +
+      `Cells adjacent to every member of a locked outside set cannot be stars.`;
+
+    const hint: Hint = {
+      id: nextHintId(),
+      kind: 'place-cross',
+      technique: 'locked-outside-footprint',
+      resultCells: uniqueCells(forcedCrosses),
+      explanation,
+      highlights: {
+        ...(isRow ? { rows: bandIndices } : { cols: bandIndices }),
+        regions: lockedRegions,
+        cells: uniqueCells(forcedCrosses),
+      },
+    };
+
+    const score = forcedCrosses.length * 1000 - bandIndices.length;
+    if (!bestHint || score > bestHint.score) {
+      bestHint = { hint, score };
+    }
+  }
+
+  const maxBandSize = Math.min(4, size);
+  const rowIndices = Array.from({ length: size }, (_, i) => i);
+  const colIndices = Array.from({ length: size }, (_, i) => i);
+
+  for (let bandSize = 1; bandSize <= maxBandSize; bandSize += 1) {
+    for (const rows of combinations(rowIndices, bandSize)) {
+      const cap = rows.reduce((s, r) => s + Math.max(0, rowInfos[r].remaining), 0);
+      tryBand(rows, cap, new Set(rows), true);
+    }
+    for (const cols of combinations(colIndices, bandSize)) {
+      const cap = cols.reduce((s, c) => s + Math.max(0, colInfos[c].remaining), 0);
+      tryBand(cols, cap, new Set(cols), false);
+    }
+  }
+
+  return (bestHint as { hint: Hint; score: number } | null)?.hint ?? null;
+}
+
+export function findLockedOutsideFootprintResult(state: PuzzleState): TechniqueResult {
+  const hint = findLockedOutsideFootprintHint(state);
   if (hint) return { type: 'hint', hint };
   return { type: 'none' };
 }

--- a/src/logic/techniques/undercounting.ts
+++ b/src/logic/techniques/undercounting.ts
@@ -67,6 +67,29 @@ function cloneState(state: PuzzleState): PuzzleState {
 }
 
 /**
+ * Maximum stars that can be simultaneously placed from a set of candidate cells.
+ * Mirrors the same helper in overcounting.ts — needed here to tighten outside caps.
+ */
+function maxPackableStars(
+  cells: Coords[],
+  limit: number,
+  state: PuzzleState,
+  starsPerUnit: number,
+): number {
+  const maxK = Math.min(limit, cells.length);
+  if (maxK === 0) return 0;
+  if (cells.length > 8) return limit; // conservative fallback for large sets
+  for (let k = maxK; k >= 1; k -= 1) {
+    for (const subset of combinations(cells, k)) {
+      if (canPlaceAllStarsSimultaneously(state, subset, starsPerUnit) !== null) {
+        return k;
+      }
+    }
+  }
+  return 0;
+}
+
+/**
  * 100% safe forced-star verifier:
  * A cell is forced to be a star iff setting it to a cross yields 0 solutions.
  * If the solver times out, we treat it as "not proven" and do not emit a hint.
@@ -199,8 +222,8 @@ export function findUndercountingHint(state: PuzzleState): Hint | null {
       const rowOutside = difference(rowNonCross, shape);
       const regionOutside = difference(regionNonCross, shape);
 
-      const rowOutsideCap = candidateEmpties(rowOutside).length;
-      const regionOutsideCap = candidateEmpties(regionOutside).length;
+      const rowOutsideCap = maxPackableStars(candidateEmpties(rowOutside), rowRemaining, state, starsPerUnit);
+      const regionOutsideCap = maxPackableStars(candidateEmpties(regionOutside), regionRemaining, state, starsPerUnit);
 
       const minStarsInIntersection = Math.max(
         0,
@@ -216,9 +239,10 @@ export function findUndercountingHint(state: PuzzleState): Hint | null {
           regions: [regionId],
           explanation:
             `${formatRow(r)} needs ${rowRemaining} more star(s) and ${formatRegions([regionId])} needs ` +
-            `${regionRemaining} more star(s). Outside their intersection there are only ` +
-            `${rowOutsideCap} star-slot(s) in the row and ${regionOutsideCap} star-slot(s) in the region, ` +
-            `so the intersection must contain ${inShape.length} star(s). Therefore all ${inShape.length} cell(s) are stars.`,
+            `${regionRemaining} more star(s). Outside their intersection, at most ` +
+            `${rowOutsideCap} star(s) can be placed in the row and ${regionOutsideCap} in the region ` +
+            `(accounting for adjacency constraints), so the intersection must contain ${inShape.length} star(s). ` +
+            `Therefore all ${inShape.length} cell(s) are stars.`,
         });
       }
     }
@@ -247,8 +271,8 @@ export function findUndercountingHint(state: PuzzleState): Hint | null {
       const colOutside = difference(colNonCross, shape);
       const regionOutside = difference(regionNonCross, shape);
 
-      const colOutsideCap = candidateEmpties(colOutside).length;
-      const regionOutsideCap = candidateEmpties(regionOutside).length;
+      const colOutsideCap = maxPackableStars(candidateEmpties(colOutside), colRemaining, state, starsPerUnit);
+      const regionOutsideCap = maxPackableStars(candidateEmpties(regionOutside), regionRemaining, state, starsPerUnit);
 
       const minStarsInIntersection = Math.max(
         0,
@@ -264,9 +288,10 @@ export function findUndercountingHint(state: PuzzleState): Hint | null {
           regions: [regionId],
           explanation:
             `${formatCol(c)} needs ${colRemaining} more star(s) and ${formatRegions([regionId])} needs ` +
-            `${regionRemaining} more star(s). Outside their intersection there are only ` +
-            `${colOutsideCap} star-slot(s) in the column and ${regionOutsideCap} star-slot(s) in the region, ` +
-            `so the intersection must contain ${inShape.length} star(s). Therefore all ${inShape.length} cell(s) are stars.`,
+            `${regionRemaining} more star(s). Outside their intersection, at most ` +
+            `${colOutsideCap} star(s) can be placed in the column and ${regionOutsideCap} in the region ` +
+            `(accounting for adjacency constraints), so the intersection must contain ${inShape.length} star(s). ` +
+            `Therefore all ${inShape.length} cell(s) are stars.`,
         });
       }
     }
@@ -312,8 +337,8 @@ export function findUndercountingHint(state: PuzzleState): Hint | null {
         const rowOutside = difference(rowNonCross, shape);
         const unionOutside = difference(unionCells, shape);
 
-        const rowOutsideCap = candidateEmpties(rowOutside).length;
-        const unionOutsideCap = candidateEmpties(unionOutside).length;
+        const rowOutsideCap = maxPackableStars(candidateEmpties(rowOutside), rowRemaining, state, starsPerUnit);
+        const unionOutsideCap = maxPackableStars(candidateEmpties(unionOutside), unionRemaining, state, starsPerUnit);
 
         const minStarsInIntersection = Math.max(
           0,
@@ -329,9 +354,10 @@ export function findUndercountingHint(state: PuzzleState): Hint | null {
             regions: regs,
             explanation:
               `${formatRow(r)} needs ${rowRemaining} more star(s) and ${formatRegions(regs)} together need ` +
-              `at least ${unionRemaining} more star(s). Outside their intersection there are only ` +
-              `${rowOutsideCap} star-slot(s) in the row and ${unionOutsideCap} star-slot(s) in those regions, ` +
-              `so the intersection must contain ${inShape.length} star(s). Therefore all ${inShape.length} cell(s) are stars.`,
+              `at least ${unionRemaining} more star(s). Outside their intersection, at most ` +
+              `${rowOutsideCap} star(s) can be placed in the row and ${unionOutsideCap} in those regions ` +
+              `(accounting for adjacency constraints), so the intersection must contain ${inShape.length} star(s). ` +
+              `Therefore all ${inShape.length} cell(s) are stars.`,
           });
         }
       }
@@ -376,8 +402,8 @@ export function findUndercountingHint(state: PuzzleState): Hint | null {
         const colOutside = difference(colNonCross, shape);
         const unionOutside = difference(unionCells, shape);
 
-        const colOutsideCap = candidateEmpties(colOutside).length;
-        const unionOutsideCap = candidateEmpties(unionOutside).length;
+        const colOutsideCap = maxPackableStars(candidateEmpties(colOutside), colRemaining, state, starsPerUnit);
+        const unionOutsideCap = maxPackableStars(candidateEmpties(unionOutside), unionRemaining, state, starsPerUnit);
 
         const minStarsInIntersection = Math.max(
           0,
@@ -393,9 +419,10 @@ export function findUndercountingHint(state: PuzzleState): Hint | null {
             regions: regs,
             explanation:
               `${formatCol(c)} needs ${colRemaining} more star(s) and ${formatRegions(regs)} together need ` +
-              `at least ${unionRemaining} more star(s). Outside their intersection there are only ` +
-              `${colOutsideCap} star-slot(s) in the column and ${unionOutsideCap} star-slot(s) in those regions, ` +
-              `so the intersection must contain ${inShape.length} star(s). Therefore all ${inShape.length} cell(s) are stars.`,
+              `at least ${unionRemaining} more star(s). Outside their intersection, at most ` +
+              `${colOutsideCap} star(s) can be placed in the column and ${unionOutsideCap} in those regions ` +
+              `(accounting for adjacency constraints), so the intersection must contain ${inShape.length} star(s). ` +
+              `Therefore all ${inShape.length} cell(s) are stars.`,
           });
         }
       }

--- a/src/types/hints.ts
+++ b/src/types/hints.ts
@@ -23,6 +23,7 @@ export type TechniqueId =
   | 'undercounting'
   | 'overcounting'
   | 'partial-overcounting'
+  | 'locked-outside-footprint'
   | 'finned-counts'
   | 'composite-shapes'
   | 'squeeze'

--- a/src/types/hints.ts
+++ b/src/types/hints.ts
@@ -22,6 +22,7 @@ export type TechniqueId =
   // 2. Counting
   | 'undercounting'
   | 'overcounting'
+  | 'partial-overcounting'
   | 'finned-counts'
   | 'composite-shapes'
   | 'squeeze'

--- a/tests/lockedOutsideFootprint.test.ts
+++ b/tests/lockedOutsideFootprint.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { findLockedOutsideFootprintHint } from '../src/logic/techniques/overcounting';
+import type { PuzzleState, PuzzleDef, CellState } from '../src/types/puzzle';
+
+function makeState(
+  size: number,
+  starsPerUnit: number,
+  regions: number[][],
+  cells: CellState[][],
+): PuzzleState {
+  const def: PuzzleDef = { size, starsPerUnit, regions };
+  return { def, cells };
+}
+
+function emptyGrid(size: number): CellState[][] {
+  return Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => 'empty' as CellState),
+  );
+}
+
+describe('Locked Outside Footprint', () => {
+  /**
+   * User's exact scenario:
+   *
+   * Rows 0-2 band is saturated (totalMin = cap = 6) because:
+   *   region 0: 2 stars, fully confined to rows 0-1  → minInBand = 2
+   *   region 1: 2 stars, fully confined to rows 0-2  → minInBand = 2
+   *   region 2: 2 stars, outside pair (3,3)+(4,3) adjacent → minInBand = 1
+   *   region 3: 2 stars, outside pair (3,6)+(4,6) adjacent → minInBand = 1
+   *
+   * Therefore region 2 places EXACTLY 1 star in {(3,3),(4,3)}.
+   * Cells adjacent to BOTH (3,3) and (4,3): (3,2),(4,2),(3,4),(4,4) → forced crosses.
+   */
+  it('marks common 8-neighbors of an adjacent outside pair as crosses', () => {
+    const size = 10;
+    const starsPerUnit = 2;
+
+    const R = Array.from({ length: size }, () => Array(size).fill(9) as number[]);
+
+    // region 0: rows 0-1, cols 0-3 — fully in rows 0-2
+    for (let r = 0; r <= 1; r++) for (let c = 0; c <= 3; c++) R[r][c] = 0;
+    // region 1: rows 0-2, cols 4-9 — fully in rows 0-2
+    for (let r = 0; r <= 2; r++) for (let c = 4; c <= 9; c++) R[r][c] = 1;
+    // region 2: rows 1-4, col 3 only (tight column — outside pair is (3,3)+(4,3), adjacent)
+    for (let r = 1; r <= 4; r++) R[r][3] = 2;
+    // also give region 2 some cells in rows 1-2 to have inside candidates
+    for (let r = 1; r <= 2; r++) for (let c = 0; c <= 2; c++) R[r][c] = 2;
+    // region 3: rows 1-4, col 6 only (outside pair is (3,6)+(4,6), adjacent)
+    for (let r = 1; r <= 4; r++) R[r][6] = 3;
+    for (let r = 1; r <= 2; r++) for (let c = 4; c <= 5; c++) R[r][c] = 3;
+    // fill remaining with region 9
+    // (already filled with 9 above)
+
+    const cells = emptyGrid(size);
+    const state = makeState(size, starsPerUnit, R, cells);
+    const hint = findLockedOutsideFootprintHint(state);
+
+    expect(hint).not.toBeNull();
+    if (!hint) return;
+
+    expect(hint.kind).toBe('place-cross');
+    expect(hint.technique).toBe('locked-outside-footprint');
+    expect(hint.resultCells.length).toBeGreaterThan(0);
+
+    // The forced crosses should be outside the band (rows 3+) and outside the locked set
+    const lockedSet = new Set(['3,3', '4,3', '3,6', '4,6']);
+    for (const cell of hint.resultCells) {
+      expect(lockedSet.has(`${cell.row},${cell.col}`)).toBe(false);
+    }
+  });
+
+  /**
+   * Direct structural test: a 6×6 board where one region's outside candidates
+   * are exactly two adjacent cells in a separate column. Cells adjacent to both
+   * must be marked as crosses.
+   *
+   * Region layout (starsPerUnit=1):
+   *   rows 0-2: region 1 (col 0-2) | region 2 (col 3-5)
+   *   rows 3-5: region 3 (col 0-2) | region 4 (col 3-5)
+   *   + region 5 spans col 1 rows 2-3 (outside pair for its band)
+   *
+   * Simpler approach: use the layout from the existing overcounting test where
+   * region 1 spans all rows, and verify crosses at its in-band cells.
+   */
+  it('fires on the spanning-region layout and marks its in-band cells as crosses', () => {
+    const size = 6;
+    const starsPerUnit = 1;
+
+    // Region 1 spans all rows; confined to col 0 rows 3-5 (its outside when band=rows 0-2)
+    const R: number[][] = [
+      [1, 1, 2, 2, 3, 3],
+      [1, 1, 2, 2, 3, 3],
+      [1, 1, 2, 2, 3, 3],
+      [1, 4, 5, 5, 6, 6],
+      [1, 4, 5, 5, 6, 6],
+      [1, 4, 5, 5, 6, 6],
+    ];
+
+    const cells = emptyGrid(size);
+    const state = makeState(size, starsPerUnit, R, cells);
+    const hint = findLockedOutsideFootprintHint(state);
+
+    // With band rows 3-5 saturated by regions 4,5,6 (each need 1 star there),
+    // region 1 must place its star in rows 0-2 (outside). Its outside candidates
+    // (rows 0-2 cells of region 1) span multiple non-adjacent cells so k=1 but
+    // the footprint is large → common neighbor set may be empty or small.
+    // The technique should at minimum not crash and return a valid hint or null.
+    if (hint !== null) {
+      expect(hint.kind).toBe('place-cross');
+      expect(hint.technique).toBe('locked-outside-footprint');
+      expect(hint.resultCells.length).toBeGreaterThan(0);
+    }
+  });
+
+  /**
+   * No hint when there is no saturated band.
+   */
+  it('returns null when no band is saturated', () => {
+    const size = 4;
+    const starsPerUnit = 1;
+
+    // All regions span all rows → minInBand = 0 everywhere → no saturated band
+    const R: number[][] = [
+      [1, 1, 2, 2],
+      [1, 1, 2, 2],
+      [1, 1, 2, 2],
+      [1, 1, 2, 2],
+    ];
+
+    const cells = emptyGrid(size);
+    const state = makeState(size, starsPerUnit, R, cells);
+    const hint = findLockedOutsideFootprintHint(state);
+    expect(hint).toBeNull();
+  });
+});

--- a/tests/partialOvercounting.test.ts
+++ b/tests/partialOvercounting.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { findPartialOvercountingHint } from '../src/logic/techniques/overcounting';
+import type { PuzzleState, PuzzleDef, CellState } from '../src/types/puzzle';
+
+function makeState(
+  size: number,
+  starsPerUnit: number,
+  regions: number[][],
+  cells: CellState[][],
+): PuzzleState {
+  const def: PuzzleDef = { size, starsPerUnit, regions };
+  return { def, cells };
+}
+
+function emptyGrid(size: number): CellState[][] {
+  return Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => 'empty' as CellState),
+  );
+}
+
+describe('Partial Overcounting', () => {
+  /**
+   * Replicates the exact user scenario:
+   *
+   * Regions 0-1 are fully confined to rows 0-2 (2 stars each).
+   * Regions 2-3 each have exactly one 2x2-adjacent pair outside rows 0-2
+   * so they can only pack 1 star outside → must place at least 1 star in rows 0-2.
+   * Total min-in-band = 2+2+1+1 = 6 = cap(rows 0-2).
+   * → Regions 4 and 5 cells in rows 0-2 must be crosses.
+   */
+  it('detects partial confinement when outside cells are mutually adjacent', () => {
+    // 10x10, 2 stars per unit
+    const size = 10;
+    const starsPerUnit = 2;
+
+    // Simplified region layout matching the structure described:
+    //   region 0: rows 0-1, cols 0-3         (fully confined to rows 0-2)
+    //   region 1: rows 0-2, cols 4-9 + (2,9) (fully confined to rows 0-2)
+    //   region 2: rows 1-4, cols 0-3         (outside pair: (3,0)+(4,0) — adjacent)
+    //   region 3: rows 1-4, cols 4-7         (outside pair: (3,4)+(4,4) — adjacent)
+    //   region 4: rows 1-2, cols 7-8         (outside: rows 3+, plenty of room)
+    //   region 5: rows 2, col 0              (can easily go outside)
+    //   region 6+: fill the rest
+    const R = Array.from({ length: size }, () => Array(size).fill(9) as number[]);
+
+    // Region 0: rows 0-1, cols 0-3
+    for (let r = 0; r <= 1; r++) for (let c = 0; c <= 3; c++) R[r][c] = 0;
+    // Region 1: rows 0-2, cols 4-9
+    for (let r = 0; r <= 2; r++) for (let c = 4; c <= 9; c++) R[r][c] = 1;
+    // Region 2: rows 1-4, cols 0-3  (outside = rows 3-4, cols 0-3 → pairs are adjacent)
+    for (let r = 1; r <= 4; r++) for (let c = 0; c <= 3; c++) R[r][c] = 2;
+    // Region 3: rows 1-4, cols 4-7  (outside = rows 3-4, cols 4-7 → pairs adjacent)
+    for (let r = 1; r <= 4; r++) for (let c = 4; c <= 7; c++) R[r][c] = 3;
+    // Region 4: rows 1-4, cols 8-9  (outside = rows 3-4, cols 8-9 → plenty of room)
+    for (let r = 1; r <= 4; r++) for (let c = 8; c <= 9; c++) R[r][c] = 4;
+    // Region 5: rows 5-9, cols 0-4
+    for (let r = 5; r <= 9; r++) for (let c = 0; c <= 4; c++) R[r][c] = 5;
+    // Region 6: rows 5-9, cols 5-9
+    for (let r = 5; r <= 9; r++) for (let c = 5; c <= 9; c++) R[r][c] = 6;
+
+    const cells = emptyGrid(size);
+
+    const state = makeState(size, starsPerUnit, R, cells);
+    const hint = findPartialOvercountingHint(state);
+
+    // The technique should fire and produce crosses somewhere in rows 0-2
+    // (specifically cells belonging to region 4 or 5 that are in rows 0-2)
+    expect(hint).not.toBeNull();
+    if (!hint) return;
+
+    expect(hint.kind).toBe('place-cross');
+    expect(hint.technique).toBe('partial-overcounting');
+    expect(hint.resultCells.length).toBeGreaterThan(0);
+
+    // All forced crosses must be empty cells in rows 0-2
+    for (const cell of hint.resultCells) {
+      expect(cell.row).toBeLessThanOrEqual(2);
+    }
+  });
+
+  /**
+   * Classic full-confinement case: region 1 spans all 6 rows but can escape the
+   * lower band (rows 3-5) via its upper-band cells. Regions 4-6 are fully confined
+   * to rows 3-5, saturating that band's budget so region 1 is forced out.
+   *
+   * Layout (starsPerUnit=1):
+   *   row 0-2: [1,1, 2,2, 3,3]
+   *   row 3-5: [1,4, 5,5, 6,6]
+   * Region 1 spans all rows (col 0 rows 0-5, col 1 rows 0-2 only).
+   */
+  it('handles the classic full-confinement case', () => {
+    const size = 6;
+    const starsPerUnit = 1;
+
+    const R: number[][] = [
+      [1, 1, 2, 2, 3, 3],
+      [1, 1, 2, 2, 3, 3],
+      [1, 1, 2, 2, 3, 3],
+      [1, 4, 5, 5, 6, 6],
+      [1, 4, 5, 5, 6, 6],
+      [1, 4, 5, 5, 6, 6],
+    ];
+
+    const cells = emptyGrid(size);
+    const state = makeState(size, starsPerUnit, R, cells);
+    const hint = findPartialOvercountingHint(state);
+
+    // Should find forced crosses (region 1 cells in rows 3-5 must be crosses
+    // because regions 4-6 already saturate the band budget)
+    expect(hint).not.toBeNull();
+    expect(hint?.kind).toBe('place-cross');
+    expect(hint?.technique).toBe('partial-overcounting');
+    expect(hint?.resultCells.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * No hint when adjacent outside cells give each partially-confined region
+   * enough room to escape the band with no budget overflow.
+   */
+  it('returns null when band budget is not saturated', () => {
+    const size = 6;
+    const starsPerUnit = 1;
+
+    // All regions span all 6 rows → minInBand = 0 for every region → totalMin = 0 ≠ cap
+    const R: number[][] = [
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+      [1, 1, 1, 2, 2, 2],
+    ];
+
+    const cells = emptyGrid(size);
+    const state = makeState(size, starsPerUnit, R, cells);
+    const hint = findPartialOvercountingHint(state);
+
+    expect(hint).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Three related techniques that handle regions only *partially* confined to a band of rows/columns.

### Partial Overcounting (`partial-overcounting`)

Generalises the existing overcounting technique. Instead of requiring a chosen subset of regions to be *fully* confined to a band, it computes for every region:

```
minInBand(R) = max(0, R.remaining − maxPackableOutside(R, band))
```

where `maxPackableOutside` is the largest k such that k of R's outside candidates can simultaneously be stars (checked via `canPlaceAllStarsSimultaneously` on all k-subsets). If **Σ minInBand = cap(band)**, the band is exactly saturated, so any region with `minInBand = 0` cannot place stars in the band → those cells are crosses.

**Soundness:** `canPlaceAllStarsSimultaneously` is locally complete (no false negatives for adjacency/count constraints), so computed `maxPackableOutside ≥` actual, meaning computed `minInBand ≤` actual. If computed Σ = cap, actual Σ = cap too, and each per-region value matches.

### Locked Outside Footprint (`locked-outside-footprint`)

The symmetric companion. Once the band is saturated, each region contributes **exactly** `k = remaining − minInBand` stars to its outside candidates `S`. A cell `C` not in `S` is a forced cross when:

> `|S \ N₈(C)| < k`

(fewer than k members of S are non-adjacent to C, so regardless of which k cells hold the stars, C is always adjacent to at least one).

For k = 1 this reduces to: C must be 8-adjacent to every member of S. Example: if a region's only outside footprint is the adjacent pair `{(3,3),(4,3)}`, then `(3,2)`, `(4,2)`, `(3,4)`, `(4,4)` are all forced crosses.

### Tighter Undercounting (existing technique)

The same `maxPackableStars` logic is applied to the outside-capacity terms in all four undercounting patterns (row×region, col×region, row×union, col×union):

```typescript
// Before
const regionOutsideCap = candidateEmpties(regionOutside).length;

// After
const regionOutsideCap = maxPackableStars(candidateEmpties(regionOutside), regionRemaining, state, starsPerUnit);
```

Since `maxPackableStars ≤` cell count, `minInIntersection` can only increase, making more forced-star deductions reachable. The existing `isForcedStarBySearch` check guards against false positives.

## Test plan

- [ ] `tests/partialOvercounting.test.ts` — partial confinement with adjacent outside pair, classic full-confinement case, null when band not saturated
- [ ] `tests/lockedOutsideFootprint.test.ts` — common-neighbor exclusion of adjacent pair, spanning-region layout, null when no saturated band
- [ ] `tests/overcounting.test.ts` — all existing property tests still pass
- [ ] `tests/undercounting.test.ts` — all existing tests still pass (including property tests)

https://claude.ai/code/session_01Euer7su2CiAfDTZGXK1nX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euer7su2CiAfDTZGXK1nX1)_