### PR TITLE
Fix thinking indicator flickering during autosolve

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,7 +56,7 @@ const showEntanglementViewer = ref(false);
 const selectedPatternId = ref<string | null>(null);
 const showTechniqueManager = ref(false);
 
-const showThinkingIndicator = computed(() => store.isThinking);
+const showThinkingIndicator = computed(() => store.isThinking || store.isAutoSolving);
 const expandedLogEntries = ref(new Set<string>());
 function toggleLogEntry(key: string) {
   if (expandedLogEntries.value.has(key)) {


### PR DESCRIPTION
The indicator was tied solely to isThinking, which findNextHint resets
to false in its finally block after each iteration. Between loop
iterations the flag briefly went false, causing rapid show/hide flicker.

Including isAutoSolving in the computed keeps the indicator visible for
the entire duration of the Try Solve run.

https://claude.ai/code/session_01Y9WY7X2KE5F2XnTnWJfGYi