### PR TITLE
Add deduction stats expandable box below the debug log

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,7 @@ import {
   clearLog,
   setShowLog,
   setShowDebugLog,
+  setShowDeductionStats,
   clearConsoleLog,
   setRegionTheme,
   setTechniqueEnabled,
@@ -44,7 +45,7 @@ import { setupConsoleInterceptor } from './utils/consoleInterceptor';
 import type { Coords, CellState } from './types/puzzle';
 import type { TechniqueId } from './types/hints';
 import { validateState, validateRegions, getRuleViolations, isPuzzleComplete } from './logic/validation';
-import { findNextHint, techniquesInOrder } from './logic/techniques';
+import { findNextHint, techniquesInOrder, techniqueNameById } from './logic/techniques';
 import { yieldToBrowser } from './logic/yieldUtils';
 
 const importText = ref('');
@@ -893,6 +894,56 @@ watch(
                     No console logs yet. Console output will appear here.
                   </div>
                 </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="toggle-block">
+            <button type="button" class="btn secondary toggle-button" @click="setShowDeductionStats(!store.showDeductionStats)">
+              <span class="material-symbols-outlined btn__icon" aria-hidden="true">analytics</span>
+              <span class="btn__label">{{ store.showDeductionStats ? 'Hide' : 'Show' }} deduction stats</span>
+            </button>
+            <div v-if="store.showDeductionStats" class="panel-after-toggle">
+              <div class="deduction-stats-panel">
+                <div v-if="store.deductionStats.lastUpdated === null" class="log-empty">
+                  No stats yet. Request a hint to see deduction stats.
+                </div>
+                <template v-else>
+                  <div class="deduction-stats-section">
+                    <div class="deduction-stats-heading">
+                      Generated
+                      <span class="deduction-stats-total">{{ store.deductionStats.generated.total }}</span>
+                    </div>
+                    <div v-if="store.deductionStats.generated.total > 0" class="deduction-stats-rows">
+                      <div v-for="[kind, count] in Object.entries(store.deductionStats.generated.byKind)" :key="kind" class="deduction-stats-row">
+                        <span class="deduction-stats-label">{{ kind }}</span>
+                        <span class="deduction-stats-count">{{ count }}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="deduction-stats-section">
+                    <div class="deduction-stats-heading">
+                      Used
+                      <span class="deduction-stats-total">{{ store.deductionStats.used.total }}</span>
+                    </div>
+                    <div v-if="store.deductionStats.used.total > 0" class="deduction-stats-rows">
+                      <div v-for="[kind, count] in Object.entries(store.deductionStats.used.byKind)" :key="kind" class="deduction-stats-row">
+                        <span class="deduction-stats-label">{{ kind }}</span>
+                        <span class="deduction-stats-count">{{ count }}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="deduction-stats-section">
+                    <div class="deduction-stats-heading">By technique (used)</div>
+                    <div v-if="store.deductionStats.used.total > 0" class="deduction-stats-rows">
+                      <div v-for="[techId, count] in Object.entries(store.deductionStats.used.byTechnique)" :key="techId" class="deduction-stats-row">
+                        <span class="deduction-stats-label">{{ techniqueNameById[techId as keyof typeof techniqueNameById] ?? techId }}</span>
+                        <span class="deduction-stats-count">{{ count }}</span>
+                      </div>
+                    </div>
+                    <div v-else class="log-empty">None</div>
+                  </div>
+                </template>
               </div>
             </div>
           </div>

--- a/src/logic/techniques.ts
+++ b/src/logic/techniques.ts
@@ -1,7 +1,7 @@
 import type { PuzzleState } from '../types/puzzle';
 import type { Hint, TechniqueId } from '../types/hints';
 import type { TechniqueResult, Deduction } from '../types/deductions';
-import { addLogEntry, store } from '../store/puzzleStore';
+import { addLogEntry, store, updateDeductionStats } from '../store/puzzleStore';
 import { analyzeDeductionsWithContext } from './mainSolver';
 import { filterValidDeductions, mergeDeductions } from './deductionUtils';
 import { buildPuzzleCache, setActivePuzzleCache, clearActivePuzzleCache } from './puzzleCache';
@@ -348,6 +348,7 @@ export async function findNextHint(state: PuzzleState): Promise<Hint | null> {
   const startTime = performance.now();
   const testedTechniques: Array<{ technique: string; timeMs: number }> = [];
   let accumulatedDeductions: Deduction[] = [];
+  const allGeneratedDeductions: Deduction[] = [];
   const signal = store.solveAbortController?.signal ?? null;
 
   const MAX_TOTAL_TIME_MS = 30000;
@@ -371,6 +372,7 @@ export async function findNextHint(state: PuzzleState): Promise<Hint | null> {
 
   function logAndReturn(hint: Hint, techName: string, techTimeMs: number, deductionList: Deduction[]): Hint {
     store.filteredDeductions = deductionList;
+    updateDeductionStats(allGeneratedDeductions, deductionList);
     const n = hint.resultCells.length;
     const kind = hint.kind === 'place-star' ? (n !== 1 ? 'stars' : 'star') : (n !== 1 ? 'crosses' : 'cross');
     const contributingTechniques = deductionList.length > 0
@@ -448,6 +450,7 @@ export async function findNextHint(state: PuzzleState): Promise<Hint | null> {
 
       if (result.type === 'hint') {
         const deductionList = result.deductions ?? [];
+        allGeneratedDeductions.push(...deductionList);
         if (result.hint.kind === 'place-star') {
           // Star placements take priority — return immediately.
           return logAndReturn(result.hint, tech.name, techTimeMs, deductionList);
@@ -460,6 +463,7 @@ export async function findNextHint(state: PuzzleState): Promise<Hint | null> {
       }
 
       if (result.type === 'deductions') {
+        allGeneratedDeductions.push(...result.deductions);
         accumulatedDeductions = mergeDeductions(accumulatedDeductions, result.deductions);
 
         const analysis = analyzeDeductionsWithContext(accumulatedDeductions, state);
@@ -484,6 +488,7 @@ export async function findNextHint(state: PuzzleState): Promise<Hint | null> {
 
     const totalTimeMs = performance.now() - startTime;
     store.filteredDeductions = filterValidDeductions(accumulatedDeductions, state);
+    updateDeductionStats(allGeneratedDeductions, store.filteredDeductions);
     addLogEntry({
       timestamp: Date.now(),
       technique: 'None',

--- a/src/store/puzzleStore.ts
+++ b/src/store/puzzleStore.ts
@@ -31,6 +31,18 @@ export interface ConsoleLogEntry {
   formatted: string;
 }
 
+export interface DeductionBucket {
+  total: number;
+  byKind: Record<string, number>;
+  byTechnique: Record<string, number>;
+}
+
+export interface DeductionStats {
+  lastUpdated: number | null;
+  generated: DeductionBucket;
+  used: DeductionBucket;
+}
+
 export type RegionTheme = 'default' | 'pastel' | 'vibrant' | 'monochrome' | 'ocean' | 'forest' | 'sunset' | 'neon' | 'warm' | 'cool';
 
 interface StoreState {
@@ -54,6 +66,8 @@ interface StoreState {
   currentTechnique: string | null;
   disabledTechniques: TechniqueId[];
   filteredDeductions: Deduction[];
+  deductionStats: DeductionStats;
+  showDeductionStats: boolean;
   // Cooperative cancellation for long-running solver work (hint / schema / trySolve).
   solveAbortController: AbortController | null;
   // True while "Try solve" loop is running (even between hint searches).
@@ -73,6 +87,7 @@ interface StoredUIState {
   regionTheme?: RegionTheme;
   disabledTechniques?: TechniqueId[];
   showDebugLog?: boolean;
+  showDeductionStats?: boolean;
   autoMarkNeighbors?: boolean;
 }
 
@@ -136,6 +151,7 @@ function currentUIState(): StoredUIState {
     regionTheme: store.regionTheme,
     disabledTechniques: store.disabledTechniques,
     showDebugLog: store.showDebugLog,
+    showDeductionStats: store.showDeductionStats,
     autoMarkNeighbors: store.autoMarkNeighbors,
   };
 }
@@ -180,6 +196,12 @@ export const store = reactive<StoreState>({
   currentTechnique: null,
   disabledTechniques: uiState.disabledTechniques || [],
   filteredDeductions: [],
+  deductionStats: {
+    lastUpdated: null,
+    generated: { total: 0, byKind: {}, byTechnique: {} },
+    used: { total: 0, byKind: {}, byTechnique: {} },
+  },
+  showDeductionStats: uiState.showDeductionStats ?? false,
   solveAbortController: null,
   isAutoSolving: false,
   autoMarkNeighbors: uiState.autoMarkNeighbors ?? false,
@@ -242,6 +264,29 @@ export function setShowLog(show: boolean) {
 export function setShowDebugLog(show: boolean) {
   store.showDebugLog = show;
   persistUIState();
+}
+
+export function setShowDeductionStats(show: boolean) {
+  store.showDeductionStats = show;
+  persistUIState();
+}
+
+function buildBucket(deductions: Deduction[]): DeductionBucket {
+  const byKind: Record<string, number> = {};
+  const byTechnique: Record<string, number> = {};
+  for (const d of deductions) {
+    byKind[d.kind] = (byKind[d.kind] ?? 0) + 1;
+    byTechnique[d.technique] = (byTechnique[d.technique] ?? 0) + 1;
+  }
+  return { total: deductions.length, byKind, byTechnique };
+}
+
+export function updateDeductionStats(generated: Deduction[], used: Deduction[]) {
+  store.deductionStats = {
+    lastUpdated: Date.now(),
+    generated: buildBucket(generated),
+    used: buildBucket(used),
+  };
 }
 
 export function addConsoleLogEntry(entry: ConsoleLogEntry) {

--- a/src/style.css
+++ b/src/style.css
@@ -1557,6 +1557,75 @@ body {
   padding-top: 1.75rem;
 }
 
+/* Deduction stats panel styles */
+.deduction-stats-panel {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.deduction-stats-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.deduction-stats-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.deduction-stats-total {
+  background: rgba(99, 102, 241, 0.2);
+  color: #a5b4fc;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.1rem 0.45rem;
+  border-radius: 0.75rem;
+}
+
+.deduction-stats-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.deduction-stats-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.25rem;
+  background: rgba(30, 41, 59, 0.5);
+}
+
+.deduction-stats-label {
+  color: #e2e8f0;
+  font-size: 0.75rem;
+}
+
+.deduction-stats-count {
+  color: #94a3b8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  min-width: 2rem;
+  text-align: right;
+}
+
 .technique-manager {
   border: 1px solid rgba(148, 163, 184, 0.4);
   border-radius: 0.75rem;


### PR DESCRIPTION
Tracks all deductions generated during each hint search (by kind and
technique) alongside the subset actually used to produce the hint,
and displays them in a collapsible panel below the debug log.

https://claude.ai/code/session_01Jhj7uqBhQFuYizNbZo9oHT